### PR TITLE
🐛 do not provide request body to userinfo get request

### DIFF
--- a/fastapi_sso/sso/base.py
+++ b/fastapi_sso/sso/base.py
@@ -169,8 +169,8 @@ class SSOBase:
             content = response.json()
             self.oauth_client.parse_request_body_response(json.dumps(content))
 
-            uri, headers, body = self.oauth_client.add_token(await self.userinfo_endpoint)
-            response = await session.get(uri, headers=headers, content=body)
+            uri, headers, _ = self.oauth_client.add_token(await self.userinfo_endpoint)
+            response = await session.get(uri, headers=headers)
             content = response.json()
 
         return await self.openid_from_response(content)


### PR DESCRIPTION
relates #6 #8 

with migrate to httpx we introduced a bug (sorry for this, but #6 was work in progress[WIP] PR)

exception is the following:

```
File "/app/.venv/lib/python3.8/site-packages/fastapi_sso/sso/base.py", line 173, in process_login
    response = await session.get(uri, headers=headers, content=body)TypeError: get() got an unexpected keyword argument 'content'
```

`httpx.get` does not accept request body parameters, and thus there's an exception.

Facebook userinfo_endpoint does expect any information in request get, on the other hand, access token is injected into URI, so it works fine and conforms to oauth.