### PR TITLE
Allow redirect_uri to be provided at request time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,12 @@ from fastapi_sso.sso.google import GoogleSSO
 
 app = FastAPI()
 
-google_sso = GoogleSSO("my-client-id", "my-client-secret", "https://my.awesome-web.com/google/callback")
-
+google_sso = GoogleSSO("my-client-id", "my-client-secret")
 
 @app.get("/google/login")
-async def google_login():
+async def google_login(request: Request):
     """Generate login url and redirect"""
-    return await google_sso.get_login_redirect()
+    return await google_sso.get_login_redirect(redirect_uri=request.url_for("google_callback"))
 
 
 @app.get("/google/callback")
@@ -69,7 +68,7 @@ OAUTHLIB_INSECURE_TRANSPORT=1
 And make sure you pass `allow_insecure_http = True` to SSO class' constructor, such as:
 
 ```python
-google_sso = GoogleSSO("client-id", "client-secret", "callback-url", allow_insecure_http=True)
+google_sso = GoogleSSO("client-id", "client-secret", allow_insecure_http=True)
 ```
 
 See [this issue](https://github.com/tomasvotava/fastapi-sso/issues/2) for more information.
@@ -82,7 +81,7 @@ fail (e.g. when loging in from different domain then the callback is landing on)
 you may want to disable state checking by passing `use_state = False` in SSO class's constructor, such as:
 
 ```python
-google_sso = GoogleSSO("client-id", "client-secret", "callback-url", use_state=False)
+google_sso = GoogleSSO("client-id", "client-secret", use_state=False)
 ```
 
 See more on state [here](https://auth0.com/docs/configure/attack-protection/state-parameters).

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ from fastapi_sso.sso.google import GoogleSSO
 
 app = FastAPI()
 
-google_sso = GoogleSSO("my-client-id", "my-client-secret")
+google_sso = GoogleSSO("my-client-id", "my-client-secret", "https://my.awesome-web.com/google/callback")
 
 @app.get("/google/login")
-async def google_login(request: Request):
+async def google_login():
     """Generate login url and redirect"""
-    return await google_sso.get_login_redirect(redirect_uri=request.url_for("google_callback"))
+    return await google_sso.get_login_redirect()
 
 
 @app.get("/google/callback")
@@ -54,6 +54,26 @@ async def google_callback(request: Request):
 ```
 
 Run using `uvicorn example:app`.
+
+### Specify `request_uri` on request time
+
+In scenarios you cannot provide the `request_uri` upon the SSO class initialization, you may simply omit
+the parameter and provide it when calling `get_login_redirect` method.
+
+```python
+...
+
+google_sso = GoogleSSO("my-client-id", "my-client-secret")
+
+@app.get("/google/login")
+async def google_login(request: Request):
+    """Generate login url and redirect"""
+    return await google_sso.get_login_redirect(redirect_uri=request.url_for("google_callback"))
+
+@app.get("/google/callback")
+async def google_callback(request: Request):
+    ...
+```
 
 ## HTTP and development
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
 <pre><code class="language-python">&quot;&quot;&quot;This is an example usage of fastapi-sso.
 &quot;&quot;&quot;
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from starlette.requests import Request
 from fastapi_sso.sso.google import GoogleSSO
 
@@ -49,6 +49,8 @@ async def google_login():
 async def google_callback(request: Request):
     &quot;&quot;&quot;Process login response from Google and return user info&quot;&quot;&quot;
     user = await google_sso.verify_and_process(request)
+    if user is None:
+        raise HTTPException(401, &quot;Failed to fetch user information&quot;)
     return {
         &quot;id&quot;: user.id,
         &quot;picture&quot;: user.picture,
@@ -56,6 +58,7 @@ async def google_callback(request: Request):
         &quot;email&quot;: user.email,
         &quot;provider&quot;: user.provider,
     }
+
 </code></pre>
 <details class="source">
 <summary>
@@ -72,7 +75,7 @@ async def google_callback(request: Request):
 \&#34;&#34;&#34;This is an example usage of fastapi-sso.
 \&#34;&#34;&#34;
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from starlette.requests import Request
 from fastapi_sso.sso.google import GoogleSSO
 
@@ -91,6 +94,8 @@ async def google_login():
 async def google_callback(request: Request):
     \&#34;&#34;&#34;Process login response from Google and return user info\&#34;&#34;&#34;
     user = await google_sso.verify_and_process(request)
+    if user is None:
+        raise HTTPException(401, &#34;Failed to fetch user information&#34;)
     return {
         &#34;id&#34;: user.id,
         &#34;picture&#34;: user.picture,
@@ -98,6 +103,7 @@ async def google_callback(request: Request):
         &#34;email&#34;: user.email,
         &#34;provider&#34;: user.provider,
     }
+
 ```
 &#34;&#34;&#34;</code></pre>
 </details>

--- a/docs/sso/base.html
+++ b/docs/sso/base.html
@@ -67,7 +67,7 @@ class SSOBase:
     provider = NotImplemented
     client_id: str = NotImplemented
     client_secret: str = NotImplemented
-    redirect_uri: str = NotImplemented
+    redirect_uri: Optional[str] = NotImplemented
     scope: List[str] = NotImplemented
     _oauth_client: Optional[WebApplicationClient] = None
     state: Optional[str] = None
@@ -76,10 +76,11 @@ class SSOBase:
         self,
         client_id: str,
         client_secret: str,
-        redirect_uri: str,
+        redirect_uri: Optional[str] = None,
         allow_insecure_http: bool = False,
         use_state: bool = True,
     ):
+        # pylint: disable=too-many-arguments
         self.client_id = client_id
         self.client_secret = client_secret
         self.redirect_uri = redirect_uri
@@ -128,22 +129,27 @@ class SSOBase:
         discovery = await self.get_discovery_document()
         return discovery.get(&#34;userinfo_endpoint&#34;)
 
-    async def get_login_url(self) -&gt; str:
+    async def get_login_url(self, redirect_uri: Optional[str] = None) -&gt; str:
         &#34;&#34;&#34;Return prepared login url. This is low-level, see {get_login_redirect} instead.&#34;&#34;&#34;
+        if redirect_uri is None:
+            if self.redirect_uri is None:
+                raise ValueError(&#34;redirect_uri must be provided, either at construction or request time&#34;)
+            redirect_uri = self.redirect_uri
+
         if self.use_state:
             self.state = str(uuid4())
         request_uri = self.oauth_client.prepare_request_uri(
-            await self.authorization_endpoint, redirect_uri=self.redirect_uri, state=self.state, scope=self.scope
+            await self.authorization_endpoint, redirect_uri=redirect_uri, state=self.state, scope=self.scope
         )
         return request_uri
 
-    async def get_login_redirect(self) -&gt; RedirectResponse:
+    async def get_login_redirect(self, redirect_uri: Optional[str] = None) -&gt; RedirectResponse:
         &#34;&#34;&#34;Return redirect response by Stalette to login page of Oauth SSO provider
 
         Returns:
             RedirectResponse -- Starlette response (may directly be returned from FastAPI)
         &#34;&#34;&#34;
-        login_uri = await self.get_login_url()
+        login_uri = await self.get_login_url(redirect_uri=redirect_uri)
         response = RedirectResponse(login_uri, 303)
         if self.state is not None and self.use_state:
             response.set_cookie(&#34;ssostate&#34;, self.state, expires=600)
@@ -176,6 +182,7 @@ class SSOBase:
         &#34;&#34;&#34;This method should be called from callback endpoint to verify the user and request user info endpoint.
         This is low level, you should use {verify_and_process} instead.
         &#34;&#34;&#34;
+        # pylint: disable=too-many-locals
         url = request.url
         scheme = url.scheme
         if not self.allow_insecure_http and scheme != &#34;https&#34;:
@@ -198,8 +205,8 @@ class SSOBase:
             content = response.json()
             self.oauth_client.parse_request_body_response(json.dumps(content))
 
-            uri, headers, body = self.oauth_client.add_token(await self.userinfo_endpoint)
-            response = await session.get(uri, headers=headers, content=body)
+            uri, headers, _ = self.oauth_client.add_token(await self.userinfo_endpoint)
+            response = await session.get(uri, headers=headers)
             content = response.json()
 
         return await self.openid_from_response(content)</code></pre>
@@ -244,31 +251,31 @@ class SSOBase:
 </ul>
 <h3>Class variables</h3>
 <dl>
-<dt id="fastapi_sso.sso.base.OpenID.display_name"><code class="name">var <span class="ident">display_name</span> : Optional[str]</code></dt>
+<dt id="fastapi_sso.sso.base.OpenID.display_name"><code class="name">var <span class="ident">display_name</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.base.OpenID.email"><code class="name">var <span class="ident">email</span> : Optional[str]</code></dt>
+<dt id="fastapi_sso.sso.base.OpenID.email"><code class="name">var <span class="ident">email</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.base.OpenID.first_name"><code class="name">var <span class="ident">first_name</span> : Optional[str]</code></dt>
+<dt id="fastapi_sso.sso.base.OpenID.first_name"><code class="name">var <span class="ident">first_name</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.base.OpenID.id"><code class="name">var <span class="ident">id</span> : Optional[str]</code></dt>
+<dt id="fastapi_sso.sso.base.OpenID.id"><code class="name">var <span class="ident">id</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.base.OpenID.last_name"><code class="name">var <span class="ident">last_name</span> : Optional[str]</code></dt>
+<dt id="fastapi_sso.sso.base.OpenID.last_name"><code class="name">var <span class="ident">last_name</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.base.OpenID.picture"><code class="name">var <span class="ident">picture</span> : Optional[str]</code></dt>
+<dt id="fastapi_sso.sso.base.OpenID.picture"><code class="name">var <span class="ident">picture</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.base.OpenID.provider"><code class="name">var <span class="ident">provider</span> : Optional[str]</code></dt>
+<dt id="fastapi_sso.sso.base.OpenID.provider"><code class="name">var <span class="ident">provider</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -276,7 +283,7 @@ class SSOBase:
 </dd>
 <dt id="fastapi_sso.sso.base.SSOBase"><code class="flex name class">
 <span>class <span class="ident">SSOBase</span></span>
-<span>(</span><span>client_id: str, client_secret: str, redirect_uri: str, allow_insecure_http: bool = False, use_state: bool = True)</span>
+<span>(</span><span>client_id: str, client_secret: str, redirect_uri: Union[str, NoneType] = None, allow_insecure_http: bool = False, use_state: bool = True)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Base class (mixin) for all SSO providers</p></div>
@@ -290,7 +297,7 @@ class SSOBase:
     provider = NotImplemented
     client_id: str = NotImplemented
     client_secret: str = NotImplemented
-    redirect_uri: str = NotImplemented
+    redirect_uri: Optional[str] = NotImplemented
     scope: List[str] = NotImplemented
     _oauth_client: Optional[WebApplicationClient] = None
     state: Optional[str] = None
@@ -299,10 +306,11 @@ class SSOBase:
         self,
         client_id: str,
         client_secret: str,
-        redirect_uri: str,
+        redirect_uri: Optional[str] = None,
         allow_insecure_http: bool = False,
         use_state: bool = True,
     ):
+        # pylint: disable=too-many-arguments
         self.client_id = client_id
         self.client_secret = client_secret
         self.redirect_uri = redirect_uri
@@ -351,22 +359,27 @@ class SSOBase:
         discovery = await self.get_discovery_document()
         return discovery.get(&#34;userinfo_endpoint&#34;)
 
-    async def get_login_url(self) -&gt; str:
+    async def get_login_url(self, redirect_uri: Optional[str] = None) -&gt; str:
         &#34;&#34;&#34;Return prepared login url. This is low-level, see {get_login_redirect} instead.&#34;&#34;&#34;
+        if redirect_uri is None:
+            if self.redirect_uri is None:
+                raise ValueError(&#34;redirect_uri must be provided, either at construction or request time&#34;)
+            redirect_uri = self.redirect_uri
+
         if self.use_state:
             self.state = str(uuid4())
         request_uri = self.oauth_client.prepare_request_uri(
-            await self.authorization_endpoint, redirect_uri=self.redirect_uri, state=self.state, scope=self.scope
+            await self.authorization_endpoint, redirect_uri=redirect_uri, state=self.state, scope=self.scope
         )
         return request_uri
 
-    async def get_login_redirect(self) -&gt; RedirectResponse:
+    async def get_login_redirect(self, redirect_uri: Optional[str] = None) -&gt; RedirectResponse:
         &#34;&#34;&#34;Return redirect response by Stalette to login page of Oauth SSO provider
 
         Returns:
             RedirectResponse -- Starlette response (may directly be returned from FastAPI)
         &#34;&#34;&#34;
-        login_uri = await self.get_login_url()
+        login_uri = await self.get_login_url(redirect_uri=redirect_uri)
         response = RedirectResponse(login_uri, 303)
         if self.state is not None and self.use_state:
             response.set_cookie(&#34;ssostate&#34;, self.state, expires=600)
@@ -399,6 +412,7 @@ class SSOBase:
         &#34;&#34;&#34;This method should be called from callback endpoint to verify the user and request user info endpoint.
         This is low level, you should use {verify_and_process} instead.
         &#34;&#34;&#34;
+        # pylint: disable=too-many-locals
         url = request.url
         scheme = url.scheme
         if not self.allow_insecure_http and scheme != &#34;https&#34;:
@@ -421,8 +435,8 @@ class SSOBase:
             content = response.json()
             self.oauth_client.parse_request_body_response(json.dumps(content))
 
-            uri, headers, body = self.oauth_client.add_token(await self.userinfo_endpoint)
-            response = await session.get(uri, headers=headers, content=body)
+            uri, headers, _ = self.oauth_client.add_token(await self.userinfo_endpoint)
+            response = await session.get(uri, headers=headers)
             content = response.json()
 
         return await self.openid_from_response(content)</code></pre>
@@ -448,7 +462,7 @@ class SSOBase:
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.base.SSOBase.redirect_uri"><code class="name">var <span class="ident">redirect_uri</span> : str</code></dt>
+<dt id="fastapi_sso.sso.base.SSOBase.redirect_uri"><code class="name">var <span class="ident">redirect_uri</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -456,7 +470,7 @@ class SSOBase:
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.base.SSOBase.state"><code class="name">var <span class="ident">state</span> : Optional[str]</code></dt>
+<dt id="fastapi_sso.sso.base.SSOBase.state"><code class="name">var <span class="ident">state</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -496,7 +510,7 @@ async def openid_from_response(cls, response: dict) -&gt; OpenID:
 </dl>
 <h3>Instance variables</h3>
 <dl>
-<dt id="fastapi_sso.sso.base.SSOBase.access_token"><code class="name">var <span class="ident">access_token</span> : Optional[str]</code></dt>
+<dt id="fastapi_sso.sso.base.SSOBase.access_token"><code class="name">var <span class="ident">access_token</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"><p>Access token from token endpoint</p></div>
 <details class="source">
@@ -509,7 +523,7 @@ def access_token(self) -&gt; Optional[str]:
     return self._oauth_client.access_token</code></pre>
 </details>
 </dd>
-<dt id="fastapi_sso.sso.base.SSOBase.authorization_endpoint"><code class="name">var <span class="ident">authorization_endpoint</span> : Optional[str]</code></dt>
+<dt id="fastapi_sso.sso.base.SSOBase.authorization_endpoint"><code class="name">var <span class="ident">authorization_endpoint</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"><p>Return <code>authorization_endpoint</code> from discovery document</p></div>
 <details class="source">
@@ -540,7 +554,7 @@ def oauth_client(self) -&gt; WebApplicationClient:
     return self._oauth_client</code></pre>
 </details>
 </dd>
-<dt id="fastapi_sso.sso.base.SSOBase.token_endpoint"><code class="name">var <span class="ident">token_endpoint</span> : Optional[str]</code></dt>
+<dt id="fastapi_sso.sso.base.SSOBase.token_endpoint"><code class="name">var <span class="ident">token_endpoint</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"><p>Return <code>token_endpoint</code> from discovery document</p></div>
 <details class="source">
@@ -554,7 +568,7 @@ async def token_endpoint(self) -&gt; Optional[str]:
     return discovery.get(&#34;token_endpoint&#34;)</code></pre>
 </details>
 </dd>
-<dt id="fastapi_sso.sso.base.SSOBase.userinfo_endpoint"><code class="name">var <span class="ident">userinfo_endpoint</span> : Optional[str]</code></dt>
+<dt id="fastapi_sso.sso.base.SSOBase.userinfo_endpoint"><code class="name">var <span class="ident">userinfo_endpoint</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"><p>Return <code>userinfo_endpoint</code> from discovery document</p></div>
 <details class="source">
@@ -572,7 +586,7 @@ async def userinfo_endpoint(self) -&gt; Optional[str]:
 <h3>Methods</h3>
 <dl>
 <dt id="fastapi_sso.sso.base.SSOBase.get_login_redirect"><code class="name flex">
-<span>async def <span class="ident">get_login_redirect</span></span>(<span>self) ‑> starlette.responses.RedirectResponse</span>
+<span>async def <span class="ident">get_login_redirect</span></span>(<span>self, redirect_uri: Union[str, NoneType] = None) ‑> starlette.responses.RedirectResponse</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Return redirect response by Stalette to login page of Oauth SSO provider</p>
@@ -582,13 +596,13 @@ async def userinfo_endpoint(self) -&gt; Optional[str]:
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">async def get_login_redirect(self) -&gt; RedirectResponse:
+<pre><code class="python">async def get_login_redirect(self, redirect_uri: Optional[str] = None) -&gt; RedirectResponse:
     &#34;&#34;&#34;Return redirect response by Stalette to login page of Oauth SSO provider
 
     Returns:
         RedirectResponse -- Starlette response (may directly be returned from FastAPI)
     &#34;&#34;&#34;
-    login_uri = await self.get_login_url()
+    login_uri = await self.get_login_url(redirect_uri=redirect_uri)
     response = RedirectResponse(login_uri, 303)
     if self.state is not None and self.use_state:
         response.set_cookie(&#34;ssostate&#34;, self.state, expires=600)
@@ -596,7 +610,7 @@ async def userinfo_endpoint(self) -&gt; Optional[str]:
 </details>
 </dd>
 <dt id="fastapi_sso.sso.base.SSOBase.get_login_url"><code class="name flex">
-<span>async def <span class="ident">get_login_url</span></span>(<span>self) ‑> str</span>
+<span>async def <span class="ident">get_login_url</span></span>(<span>self, redirect_uri: Union[str, NoneType] = None) ‑> str</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Return prepared login url. This is low-level, see {get_login_redirect} instead.</p></div>
@@ -604,18 +618,23 @@ async def userinfo_endpoint(self) -&gt; Optional[str]:
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">async def get_login_url(self) -&gt; str:
+<pre><code class="python">async def get_login_url(self, redirect_uri: Optional[str] = None) -&gt; str:
     &#34;&#34;&#34;Return prepared login url. This is low-level, see {get_login_redirect} instead.&#34;&#34;&#34;
+    if redirect_uri is None:
+        if self.redirect_uri is None:
+            raise ValueError(&#34;redirect_uri must be provided, either at construction or request time&#34;)
+        redirect_uri = self.redirect_uri
+
     if self.use_state:
         self.state = str(uuid4())
     request_uri = self.oauth_client.prepare_request_uri(
-        await self.authorization_endpoint, redirect_uri=self.redirect_uri, state=self.state, scope=self.scope
+        await self.authorization_endpoint, redirect_uri=redirect_uri, state=self.state, scope=self.scope
     )
     return request_uri</code></pre>
 </details>
 </dd>
 <dt id="fastapi_sso.sso.base.SSOBase.process_login"><code class="name flex">
-<span>async def <span class="ident">process_login</span></span>(<span>self, code: str, request: starlette.requests.Request) ‑> Optional[<a title="fastapi_sso.sso.base.OpenID" href="#fastapi_sso.sso.base.OpenID">OpenID</a>]</span>
+<span>async def <span class="ident">process_login</span></span>(<span>self, code: str, request: starlette.requests.Request) ‑> Union[<a title="fastapi_sso.sso.base.OpenID" href="#fastapi_sso.sso.base.OpenID">OpenID</a>, NoneType]</span>
 </code></dt>
 <dd>
 <div class="desc"><p>This method should be called from callback endpoint to verify the user and request user info endpoint.
@@ -628,6 +647,7 @@ This is low level, you should use {verify_and_process} instead.</p></div>
     &#34;&#34;&#34;This method should be called from callback endpoint to verify the user and request user info endpoint.
     This is low level, you should use {verify_and_process} instead.
     &#34;&#34;&#34;
+    # pylint: disable=too-many-locals
     url = request.url
     scheme = url.scheme
     if not self.allow_insecure_http and scheme != &#34;https&#34;:
@@ -650,15 +670,15 @@ This is low level, you should use {verify_and_process} instead.</p></div>
         content = response.json()
         self.oauth_client.parse_request_body_response(json.dumps(content))
 
-        uri, headers, body = self.oauth_client.add_token(await self.userinfo_endpoint)
-        response = await session.get(uri, headers=headers, content=body)
+        uri, headers, _ = self.oauth_client.add_token(await self.userinfo_endpoint)
+        response = await session.get(uri, headers=headers)
         content = response.json()
 
     return await self.openid_from_response(content)</code></pre>
 </details>
 </dd>
 <dt id="fastapi_sso.sso.base.SSOBase.verify_and_process"><code class="name flex">
-<span>async def <span class="ident">verify_and_process</span></span>(<span>self, request: starlette.requests.Request) ‑> Optional[<a title="fastapi_sso.sso.base.OpenID" href="#fastapi_sso.sso.base.OpenID">OpenID</a>]</span>
+<span>async def <span class="ident">verify_and_process</span></span>(<span>self, request: starlette.requests.Request) ‑> Union[<a title="fastapi_sso.sso.base.OpenID" href="#fastapi_sso.sso.base.OpenID">OpenID</a>, NoneType]</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Get FastAPI (Starlette) Request object and process login.

--- a/docs/sso/base.html
+++ b/docs/sso/base.html
@@ -99,7 +99,7 @@ class SSOBase:
     @property
     def access_token(self) -&gt; Optional[str]:
         &#34;&#34;&#34;Access token from token endpoint&#34;&#34;&#34;
-        return self._oauth_client.access_token
+        return self.oauth_client.access_token
 
     @classmethod
     async def openid_from_response(cls, response: dict) -&gt; OpenID:
@@ -129,13 +129,11 @@ class SSOBase:
         discovery = await self.get_discovery_document()
         return discovery.get(&#34;userinfo_endpoint&#34;)
 
-    async def get_login_url(self, redirect_uri: Optional[str] = None) -&gt; str:
+    async def get_login_url(self, *, redirect_uri: Optional[str] = None) -&gt; str:
         &#34;&#34;&#34;Return prepared login url. This is low-level, see {get_login_redirect} instead.&#34;&#34;&#34;
+        redirect_uri = redirect_uri or self.redirect_uri
         if redirect_uri is None:
-            if self.redirect_uri is None:
-                raise ValueError(&#34;redirect_uri must be provided, either at construction or request time&#34;)
-            redirect_uri = self.redirect_uri
-
+            raise ValueError(&#34;redirect_uri must be provided, either at construction or request time&#34;)
         if self.use_state:
             self.state = str(uuid4())
         request_uri = self.oauth_client.prepare_request_uri(
@@ -143,8 +141,11 @@ class SSOBase:
         )
         return request_uri
 
-    async def get_login_redirect(self, redirect_uri: Optional[str] = None) -&gt; RedirectResponse:
+    async def get_login_redirect(self, *, redirect_uri: Optional[str] = None) -&gt; RedirectResponse:
         &#34;&#34;&#34;Return redirect response by Stalette to login page of Oauth SSO provider
+
+        Arguments:
+            redirect_uri {Optional[str]} -- Override redirect_uri for this instance (default: None)
 
         Returns:
             RedirectResponse -- Starlette response (may directly be returned from FastAPI)
@@ -251,31 +252,31 @@ class SSOBase:
 </ul>
 <h3>Class variables</h3>
 <dl>
-<dt id="fastapi_sso.sso.base.OpenID.display_name"><code class="name">var <span class="ident">display_name</span> : Union[str, NoneType]</code></dt>
+<dt id="fastapi_sso.sso.base.OpenID.display_name"><code class="name">var <span class="ident">display_name</span> : Optional[str]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.base.OpenID.email"><code class="name">var <span class="ident">email</span> : Union[str, NoneType]</code></dt>
+<dt id="fastapi_sso.sso.base.OpenID.email"><code class="name">var <span class="ident">email</span> : Optional[str]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.base.OpenID.first_name"><code class="name">var <span class="ident">first_name</span> : Union[str, NoneType]</code></dt>
+<dt id="fastapi_sso.sso.base.OpenID.first_name"><code class="name">var <span class="ident">first_name</span> : Optional[str]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.base.OpenID.id"><code class="name">var <span class="ident">id</span> : Union[str, NoneType]</code></dt>
+<dt id="fastapi_sso.sso.base.OpenID.id"><code class="name">var <span class="ident">id</span> : Optional[str]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.base.OpenID.last_name"><code class="name">var <span class="ident">last_name</span> : Union[str, NoneType]</code></dt>
+<dt id="fastapi_sso.sso.base.OpenID.last_name"><code class="name">var <span class="ident">last_name</span> : Optional[str]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.base.OpenID.picture"><code class="name">var <span class="ident">picture</span> : Union[str, NoneType]</code></dt>
+<dt id="fastapi_sso.sso.base.OpenID.picture"><code class="name">var <span class="ident">picture</span> : Optional[str]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.base.OpenID.provider"><code class="name">var <span class="ident">provider</span> : Union[str, NoneType]</code></dt>
+<dt id="fastapi_sso.sso.base.OpenID.provider"><code class="name">var <span class="ident">provider</span> : Optional[str]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -283,7 +284,7 @@ class SSOBase:
 </dd>
 <dt id="fastapi_sso.sso.base.SSOBase"><code class="flex name class">
 <span>class <span class="ident">SSOBase</span></span>
-<span>(</span><span>client_id: str, client_secret: str, redirect_uri: Union[str, NoneType] = None, allow_insecure_http: bool = False, use_state: bool = True)</span>
+<span>(</span><span>client_id: str, client_secret: str, redirect_uri: Optional[str] = None, allow_insecure_http: bool = False, use_state: bool = True)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Base class (mixin) for all SSO providers</p></div>
@@ -329,7 +330,7 @@ class SSOBase:
     @property
     def access_token(self) -&gt; Optional[str]:
         &#34;&#34;&#34;Access token from token endpoint&#34;&#34;&#34;
-        return self._oauth_client.access_token
+        return self.oauth_client.access_token
 
     @classmethod
     async def openid_from_response(cls, response: dict) -&gt; OpenID:
@@ -359,13 +360,11 @@ class SSOBase:
         discovery = await self.get_discovery_document()
         return discovery.get(&#34;userinfo_endpoint&#34;)
 
-    async def get_login_url(self, redirect_uri: Optional[str] = None) -&gt; str:
+    async def get_login_url(self, *, redirect_uri: Optional[str] = None) -&gt; str:
         &#34;&#34;&#34;Return prepared login url. This is low-level, see {get_login_redirect} instead.&#34;&#34;&#34;
+        redirect_uri = redirect_uri or self.redirect_uri
         if redirect_uri is None:
-            if self.redirect_uri is None:
-                raise ValueError(&#34;redirect_uri must be provided, either at construction or request time&#34;)
-            redirect_uri = self.redirect_uri
-
+            raise ValueError(&#34;redirect_uri must be provided, either at construction or request time&#34;)
         if self.use_state:
             self.state = str(uuid4())
         request_uri = self.oauth_client.prepare_request_uri(
@@ -373,8 +372,11 @@ class SSOBase:
         )
         return request_uri
 
-    async def get_login_redirect(self, redirect_uri: Optional[str] = None) -&gt; RedirectResponse:
+    async def get_login_redirect(self, *, redirect_uri: Optional[str] = None) -&gt; RedirectResponse:
         &#34;&#34;&#34;Return redirect response by Stalette to login page of Oauth SSO provider
+
+        Arguments:
+            redirect_uri {Optional[str]} -- Override redirect_uri for this instance (default: None)
 
         Returns:
             RedirectResponse -- Starlette response (may directly be returned from FastAPI)
@@ -462,7 +464,7 @@ class SSOBase:
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.base.SSOBase.redirect_uri"><code class="name">var <span class="ident">redirect_uri</span> : Union[str, NoneType]</code></dt>
+<dt id="fastapi_sso.sso.base.SSOBase.redirect_uri"><code class="name">var <span class="ident">redirect_uri</span> : Optional[str]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -470,7 +472,7 @@ class SSOBase:
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.base.SSOBase.state"><code class="name">var <span class="ident">state</span> : Union[str, NoneType]</code></dt>
+<dt id="fastapi_sso.sso.base.SSOBase.state"><code class="name">var <span class="ident">state</span> : Optional[str]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -510,7 +512,7 @@ async def openid_from_response(cls, response: dict) -&gt; OpenID:
 </dl>
 <h3>Instance variables</h3>
 <dl>
-<dt id="fastapi_sso.sso.base.SSOBase.access_token"><code class="name">var <span class="ident">access_token</span> : Union[str, NoneType]</code></dt>
+<dt id="fastapi_sso.sso.base.SSOBase.access_token"><code class="name">var <span class="ident">access_token</span> : Optional[str]</code></dt>
 <dd>
 <div class="desc"><p>Access token from token endpoint</p></div>
 <details class="source">
@@ -520,10 +522,10 @@ async def openid_from_response(cls, response: dict) -&gt; OpenID:
 <pre><code class="python">@property
 def access_token(self) -&gt; Optional[str]:
     &#34;&#34;&#34;Access token from token endpoint&#34;&#34;&#34;
-    return self._oauth_client.access_token</code></pre>
+    return self.oauth_client.access_token</code></pre>
 </details>
 </dd>
-<dt id="fastapi_sso.sso.base.SSOBase.authorization_endpoint"><code class="name">var <span class="ident">authorization_endpoint</span> : Union[str, NoneType]</code></dt>
+<dt id="fastapi_sso.sso.base.SSOBase.authorization_endpoint"><code class="name">var <span class="ident">authorization_endpoint</span> : Optional[str]</code></dt>
 <dd>
 <div class="desc"><p>Return <code>authorization_endpoint</code> from discovery document</p></div>
 <details class="source">
@@ -554,7 +556,7 @@ def oauth_client(self) -&gt; WebApplicationClient:
     return self._oauth_client</code></pre>
 </details>
 </dd>
-<dt id="fastapi_sso.sso.base.SSOBase.token_endpoint"><code class="name">var <span class="ident">token_endpoint</span> : Union[str, NoneType]</code></dt>
+<dt id="fastapi_sso.sso.base.SSOBase.token_endpoint"><code class="name">var <span class="ident">token_endpoint</span> : Optional[str]</code></dt>
 <dd>
 <div class="desc"><p>Return <code>token_endpoint</code> from discovery document</p></div>
 <details class="source">
@@ -568,7 +570,7 @@ async def token_endpoint(self) -&gt; Optional[str]:
     return discovery.get(&#34;token_endpoint&#34;)</code></pre>
 </details>
 </dd>
-<dt id="fastapi_sso.sso.base.SSOBase.userinfo_endpoint"><code class="name">var <span class="ident">userinfo_endpoint</span> : Union[str, NoneType]</code></dt>
+<dt id="fastapi_sso.sso.base.SSOBase.userinfo_endpoint"><code class="name">var <span class="ident">userinfo_endpoint</span> : Optional[str]</code></dt>
 <dd>
 <div class="desc"><p>Return <code>userinfo_endpoint</code> from discovery document</p></div>
 <details class="source">
@@ -586,18 +588,23 @@ async def userinfo_endpoint(self) -&gt; Optional[str]:
 <h3>Methods</h3>
 <dl>
 <dt id="fastapi_sso.sso.base.SSOBase.get_login_redirect"><code class="name flex">
-<span>async def <span class="ident">get_login_redirect</span></span>(<span>self, redirect_uri: Union[str, NoneType] = None) ‑> starlette.responses.RedirectResponse</span>
+<span>async def <span class="ident">get_login_redirect</span></span>(<span>self, *, redirect_uri: Optional[str] = None) ‑> starlette.responses.RedirectResponse</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Return redirect response by Stalette to login page of Oauth SSO provider</p>
+<h2 id="arguments">Arguments</h2>
+<p>redirect_uri {Optional[str]} &ndash; Override redirect_uri for this instance (default: None)</p>
 <h2 id="returns">Returns</h2>
 <p>RedirectResponse &ndash; Starlette response (may directly be returned from FastAPI)</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">async def get_login_redirect(self, redirect_uri: Optional[str] = None) -&gt; RedirectResponse:
+<pre><code class="python">async def get_login_redirect(self, *, redirect_uri: Optional[str] = None) -&gt; RedirectResponse:
     &#34;&#34;&#34;Return redirect response by Stalette to login page of Oauth SSO provider
+
+    Arguments:
+        redirect_uri {Optional[str]} -- Override redirect_uri for this instance (default: None)
 
     Returns:
         RedirectResponse -- Starlette response (may directly be returned from FastAPI)
@@ -610,7 +617,7 @@ async def userinfo_endpoint(self) -&gt; Optional[str]:
 </details>
 </dd>
 <dt id="fastapi_sso.sso.base.SSOBase.get_login_url"><code class="name flex">
-<span>async def <span class="ident">get_login_url</span></span>(<span>self, redirect_uri: Union[str, NoneType] = None) ‑> str</span>
+<span>async def <span class="ident">get_login_url</span></span>(<span>self, *, redirect_uri: Optional[str] = None) ‑> str</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Return prepared login url. This is low-level, see {get_login_redirect} instead.</p></div>
@@ -618,13 +625,11 @@ async def userinfo_endpoint(self) -&gt; Optional[str]:
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">async def get_login_url(self, redirect_uri: Optional[str] = None) -&gt; str:
+<pre><code class="python">async def get_login_url(self, *, redirect_uri: Optional[str] = None) -&gt; str:
     &#34;&#34;&#34;Return prepared login url. This is low-level, see {get_login_redirect} instead.&#34;&#34;&#34;
+    redirect_uri = redirect_uri or self.redirect_uri
     if redirect_uri is None:
-        if self.redirect_uri is None:
-            raise ValueError(&#34;redirect_uri must be provided, either at construction or request time&#34;)
-        redirect_uri = self.redirect_uri
-
+        raise ValueError(&#34;redirect_uri must be provided, either at construction or request time&#34;)
     if self.use_state:
         self.state = str(uuid4())
     request_uri = self.oauth_client.prepare_request_uri(
@@ -634,7 +639,7 @@ async def userinfo_endpoint(self) -&gt; Optional[str]:
 </details>
 </dd>
 <dt id="fastapi_sso.sso.base.SSOBase.process_login"><code class="name flex">
-<span>async def <span class="ident">process_login</span></span>(<span>self, code: str, request: starlette.requests.Request) ‑> Union[<a title="fastapi_sso.sso.base.OpenID" href="#fastapi_sso.sso.base.OpenID">OpenID</a>, NoneType]</span>
+<span>async def <span class="ident">process_login</span></span>(<span>self, code: str, request: starlette.requests.Request) ‑> Optional[<a title="fastapi_sso.sso.base.OpenID" href="#fastapi_sso.sso.base.OpenID">OpenID</a>]</span>
 </code></dt>
 <dd>
 <div class="desc"><p>This method should be called from callback endpoint to verify the user and request user info endpoint.
@@ -678,7 +683,7 @@ This is low level, you should use {verify_and_process} instead.</p></div>
 </details>
 </dd>
 <dt id="fastapi_sso.sso.base.SSOBase.verify_and_process"><code class="name flex">
-<span>async def <span class="ident">verify_and_process</span></span>(<span>self, request: starlette.requests.Request) ‑> Union[<a title="fastapi_sso.sso.base.OpenID" href="#fastapi_sso.sso.base.OpenID">OpenID</a>, NoneType]</span>
+<span>async def <span class="ident">verify_and_process</span></span>(<span>self, request: starlette.requests.Request) ‑> Optional[<a title="fastapi_sso.sso.base.OpenID" href="#fastapi_sso.sso.base.OpenID">OpenID</a>]</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Get FastAPI (Starlette) Request object and process login.

--- a/docs/sso/facebook.html
+++ b/docs/sso/facebook.html
@@ -76,7 +76,7 @@ class FacebookSSO(SSOBase):
 <dl>
 <dt id="fastapi_sso.sso.facebook.FacebookSSO"><code class="flex name class">
 <span>class <span class="ident">FacebookSSO</span></span>
-<span>(</span><span>client_id: str, client_secret: str, redirect_uri: Union[str, NoneType] = None, allow_insecure_http: bool = False, use_state: bool = True)</span>
+<span>(</span><span>client_id: str, client_secret: str, redirect_uri: Optional[str] = None, allow_insecure_http: bool = False, use_state: bool = True)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Class providing login via Facebook OAuth</p></div>
@@ -123,27 +123,11 @@ class FacebookSSO(SSOBase):
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.facebook.FacebookSSO.client_id"><code class="name">var <span class="ident">client_id</span> : str</code></dt>
-<dd>
-<div class="desc"></div>
-</dd>
-<dt id="fastapi_sso.sso.facebook.FacebookSSO.client_secret"><code class="name">var <span class="ident">client_secret</span> : str</code></dt>
-<dd>
-<div class="desc"></div>
-</dd>
 <dt id="fastapi_sso.sso.facebook.FacebookSSO.provider"><code class="name">var <span class="ident">provider</span></code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.facebook.FacebookSSO.redirect_uri"><code class="name">var <span class="ident">redirect_uri</span> : Union[str, NoneType]</code></dt>
-<dd>
-<div class="desc"></div>
-</dd>
 <dt id="fastapi_sso.sso.facebook.FacebookSSO.scope"><code class="name">var <span class="ident">scope</span> : List[str]</code></dt>
-<dd>
-<div class="desc"></div>
-</dd>
-<dt id="fastapi_sso.sso.facebook.FacebookSSO.state"><code class="name">var <span class="ident">state</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -230,14 +214,10 @@ async def openid_from_response(cls, response: dict) -&gt; OpenID:
 <h4><code><a title="fastapi_sso.sso.facebook.FacebookSSO" href="#fastapi_sso.sso.facebook.FacebookSSO">FacebookSSO</a></code></h4>
 <ul class="">
 <li><code><a title="fastapi_sso.sso.facebook.FacebookSSO.base_url" href="#fastapi_sso.sso.facebook.FacebookSSO.base_url">base_url</a></code></li>
-<li><code><a title="fastapi_sso.sso.facebook.FacebookSSO.client_id" href="#fastapi_sso.sso.facebook.FacebookSSO.client_id">client_id</a></code></li>
-<li><code><a title="fastapi_sso.sso.facebook.FacebookSSO.client_secret" href="#fastapi_sso.sso.facebook.FacebookSSO.client_secret">client_secret</a></code></li>
 <li><code><a title="fastapi_sso.sso.facebook.FacebookSSO.get_discovery_document" href="#fastapi_sso.sso.facebook.FacebookSSO.get_discovery_document">get_discovery_document</a></code></li>
 <li><code><a title="fastapi_sso.sso.facebook.FacebookSSO.openid_from_response" href="#fastapi_sso.sso.facebook.FacebookSSO.openid_from_response">openid_from_response</a></code></li>
 <li><code><a title="fastapi_sso.sso.facebook.FacebookSSO.provider" href="#fastapi_sso.sso.facebook.FacebookSSO.provider">provider</a></code></li>
-<li><code><a title="fastapi_sso.sso.facebook.FacebookSSO.redirect_uri" href="#fastapi_sso.sso.facebook.FacebookSSO.redirect_uri">redirect_uri</a></code></li>
 <li><code><a title="fastapi_sso.sso.facebook.FacebookSSO.scope" href="#fastapi_sso.sso.facebook.FacebookSSO.scope">scope</a></code></li>
-<li><code><a title="fastapi_sso.sso.facebook.FacebookSSO.state" href="#fastapi_sso.sso.facebook.FacebookSSO.state">state</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/sso/facebook.html
+++ b/docs/sso/facebook.html
@@ -76,7 +76,7 @@ class FacebookSSO(SSOBase):
 <dl>
 <dt id="fastapi_sso.sso.facebook.FacebookSSO"><code class="flex name class">
 <span>class <span class="ident">FacebookSSO</span></span>
-<span>(</span><span>client_id: str, client_secret: str, redirect_uri: str, allow_insecure_http: bool = False, use_state: bool = True)</span>
+<span>(</span><span>client_id: str, client_secret: str, redirect_uri: Union[str, NoneType] = None, allow_insecure_http: bool = False, use_state: bool = True)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Class providing login via Facebook OAuth</p></div>
@@ -135,7 +135,7 @@ class FacebookSSO(SSOBase):
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.facebook.FacebookSSO.redirect_uri"><code class="name">var <span class="ident">redirect_uri</span> : str</code></dt>
+<dt id="fastapi_sso.sso.facebook.FacebookSSO.redirect_uri"><code class="name">var <span class="ident">redirect_uri</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -143,7 +143,7 @@ class FacebookSSO(SSOBase):
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.facebook.FacebookSSO.state"><code class="name">var <span class="ident">state</span> : Optional[str]</code></dt>
+<dt id="fastapi_sso.sso.facebook.FacebookSSO.state"><code class="name">var <span class="ident">state</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>

--- a/docs/sso/google.html
+++ b/docs/sso/google.html
@@ -78,7 +78,7 @@ class GoogleSSO(SSOBase):
 <dl>
 <dt id="fastapi_sso.sso.google.GoogleSSO"><code class="flex name class">
 <span>class <span class="ident">GoogleSSO</span></span>
-<span>(</span><span>client_id: str, client_secret: str, redirect_uri: Union[str, NoneType] = None, allow_insecure_http: bool = False, use_state: bool = True)</span>
+<span>(</span><span>client_id: str, client_secret: str, redirect_uri: Optional[str] = None, allow_insecure_http: bool = False, use_state: bool = True)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Class providing login via Facebook OAuth</p></div>
@@ -122,14 +122,6 @@ class GoogleSSO(SSOBase):
 </ul>
 <h3>Class variables</h3>
 <dl>
-<dt id="fastapi_sso.sso.google.GoogleSSO.client_id"><code class="name">var <span class="ident">client_id</span> : str</code></dt>
-<dd>
-<div class="desc"></div>
-</dd>
-<dt id="fastapi_sso.sso.google.GoogleSSO.client_secret"><code class="name">var <span class="ident">client_secret</span> : str</code></dt>
-<dd>
-<div class="desc"></div>
-</dd>
 <dt id="fastapi_sso.sso.google.GoogleSSO.discovery_url"><code class="name">var <span class="ident">discovery_url</span></code></dt>
 <dd>
 <div class="desc"></div>
@@ -138,15 +130,7 @@ class GoogleSSO(SSOBase):
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.google.GoogleSSO.redirect_uri"><code class="name">var <span class="ident">redirect_uri</span> : Union[str, NoneType]</code></dt>
-<dd>
-<div class="desc"></div>
-</dd>
 <dt id="fastapi_sso.sso.google.GoogleSSO.scope"><code class="name">var <span class="ident">scope</span> : List[str]</code></dt>
-<dd>
-<div class="desc"></div>
-</dd>
-<dt id="fastapi_sso.sso.google.GoogleSSO.state"><code class="name">var <span class="ident">state</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -233,15 +217,11 @@ async def openid_from_response(cls, response: dict) -&gt; OpenID:
 <li>
 <h4><code><a title="fastapi_sso.sso.google.GoogleSSO" href="#fastapi_sso.sso.google.GoogleSSO">GoogleSSO</a></code></h4>
 <ul class="">
-<li><code><a title="fastapi_sso.sso.google.GoogleSSO.client_id" href="#fastapi_sso.sso.google.GoogleSSO.client_id">client_id</a></code></li>
-<li><code><a title="fastapi_sso.sso.google.GoogleSSO.client_secret" href="#fastapi_sso.sso.google.GoogleSSO.client_secret">client_secret</a></code></li>
 <li><code><a title="fastapi_sso.sso.google.GoogleSSO.discovery_url" href="#fastapi_sso.sso.google.GoogleSSO.discovery_url">discovery_url</a></code></li>
 <li><code><a title="fastapi_sso.sso.google.GoogleSSO.get_discovery_document" href="#fastapi_sso.sso.google.GoogleSSO.get_discovery_document">get_discovery_document</a></code></li>
 <li><code><a title="fastapi_sso.sso.google.GoogleSSO.openid_from_response" href="#fastapi_sso.sso.google.GoogleSSO.openid_from_response">openid_from_response</a></code></li>
 <li><code><a title="fastapi_sso.sso.google.GoogleSSO.provider" href="#fastapi_sso.sso.google.GoogleSSO.provider">provider</a></code></li>
-<li><code><a title="fastapi_sso.sso.google.GoogleSSO.redirect_uri" href="#fastapi_sso.sso.google.GoogleSSO.redirect_uri">redirect_uri</a></code></li>
 <li><code><a title="fastapi_sso.sso.google.GoogleSSO.scope" href="#fastapi_sso.sso.google.GoogleSSO.scope">scope</a></code></li>
-<li><code><a title="fastapi_sso.sso.google.GoogleSSO.state" href="#fastapi_sso.sso.google.GoogleSSO.state">state</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/sso/google.html
+++ b/docs/sso/google.html
@@ -78,7 +78,7 @@ class GoogleSSO(SSOBase):
 <dl>
 <dt id="fastapi_sso.sso.google.GoogleSSO"><code class="flex name class">
 <span>class <span class="ident">GoogleSSO</span></span>
-<span>(</span><span>client_id: str, client_secret: str, redirect_uri: str, allow_insecure_http: bool = False, use_state: bool = True)</span>
+<span>(</span><span>client_id: str, client_secret: str, redirect_uri: Union[str, NoneType] = None, allow_insecure_http: bool = False, use_state: bool = True)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Class providing login via Facebook OAuth</p></div>
@@ -138,7 +138,7 @@ class GoogleSSO(SSOBase):
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.google.GoogleSSO.redirect_uri"><code class="name">var <span class="ident">redirect_uri</span> : str</code></dt>
+<dt id="fastapi_sso.sso.google.GoogleSSO.redirect_uri"><code class="name">var <span class="ident">redirect_uri</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -146,7 +146,7 @@ class GoogleSSO(SSOBase):
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.google.GoogleSSO.state"><code class="name">var <span class="ident">state</span> : Optional[str]</code></dt>
+<dt id="fastapi_sso.sso.google.GoogleSSO.state"><code class="name">var <span class="ident">state</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>

--- a/docs/sso/microsoft.html
+++ b/docs/sso/microsoft.html
@@ -75,7 +75,7 @@ class MicrosoftSSO(SSOBase):
 <dl>
 <dt id="fastapi_sso.sso.microsoft.MicrosoftSSO"><code class="flex name class">
 <span>class <span class="ident">MicrosoftSSO</span></span>
-<span>(</span><span>client_id: str, client_secret: str, redirect_uri: str, allow_insecure_http: bool = False, use_state: bool = True)</span>
+<span>(</span><span>client_id: str, client_secret: str, redirect_uri: Union[str, NoneType] = None, allow_insecure_http: bool = False, use_state: bool = True)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Class providing login via Microsoft Graph OAuth</p></div>
@@ -130,7 +130,7 @@ class MicrosoftSSO(SSOBase):
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.microsoft.MicrosoftSSO.redirect_uri"><code class="name">var <span class="ident">redirect_uri</span> : str</code></dt>
+<dt id="fastapi_sso.sso.microsoft.MicrosoftSSO.redirect_uri"><code class="name">var <span class="ident">redirect_uri</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -138,7 +138,7 @@ class MicrosoftSSO(SSOBase):
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.microsoft.MicrosoftSSO.state"><code class="name">var <span class="ident">state</span> : Optional[str]</code></dt>
+<dt id="fastapi_sso.sso.microsoft.MicrosoftSSO.state"><code class="name">var <span class="ident">state</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>

--- a/docs/sso/microsoft.html
+++ b/docs/sso/microsoft.html
@@ -75,7 +75,7 @@ class MicrosoftSSO(SSOBase):
 <dl>
 <dt id="fastapi_sso.sso.microsoft.MicrosoftSSO"><code class="flex name class">
 <span>class <span class="ident">MicrosoftSSO</span></span>
-<span>(</span><span>client_id: str, client_secret: str, redirect_uri: Union[str, NoneType] = None, allow_insecure_http: bool = False, use_state: bool = True)</span>
+<span>(</span><span>client_id: str, client_secret: str, redirect_uri: Optional[str] = None, allow_insecure_http: bool = False, use_state: bool = True)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Class providing login via Microsoft Graph OAuth</p></div>
@@ -118,27 +118,11 @@ class MicrosoftSSO(SSOBase):
 </ul>
 <h3>Class variables</h3>
 <dl>
-<dt id="fastapi_sso.sso.microsoft.MicrosoftSSO.client_id"><code class="name">var <span class="ident">client_id</span> : str</code></dt>
-<dd>
-<div class="desc"></div>
-</dd>
-<dt id="fastapi_sso.sso.microsoft.MicrosoftSSO.client_secret"><code class="name">var <span class="ident">client_secret</span> : str</code></dt>
-<dd>
-<div class="desc"></div>
-</dd>
 <dt id="fastapi_sso.sso.microsoft.MicrosoftSSO.provider"><code class="name">var <span class="ident">provider</span></code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.microsoft.MicrosoftSSO.redirect_uri"><code class="name">var <span class="ident">redirect_uri</span> : Union[str, NoneType]</code></dt>
-<dd>
-<div class="desc"></div>
-</dd>
 <dt id="fastapi_sso.sso.microsoft.MicrosoftSSO.scope"><code class="name">var <span class="ident">scope</span> : List[str]</code></dt>
-<dd>
-<div class="desc"></div>
-</dd>
-<dt id="fastapi_sso.sso.microsoft.MicrosoftSSO.state"><code class="name">var <span class="ident">state</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -228,14 +212,10 @@ async def openid_from_response(cls, response: dict) -&gt; OpenID:
 <li>
 <h4><code><a title="fastapi_sso.sso.microsoft.MicrosoftSSO" href="#fastapi_sso.sso.microsoft.MicrosoftSSO">MicrosoftSSO</a></code></h4>
 <ul class="">
-<li><code><a title="fastapi_sso.sso.microsoft.MicrosoftSSO.client_id" href="#fastapi_sso.sso.microsoft.MicrosoftSSO.client_id">client_id</a></code></li>
-<li><code><a title="fastapi_sso.sso.microsoft.MicrosoftSSO.client_secret" href="#fastapi_sso.sso.microsoft.MicrosoftSSO.client_secret">client_secret</a></code></li>
 <li><code><a title="fastapi_sso.sso.microsoft.MicrosoftSSO.get_discovery_document" href="#fastapi_sso.sso.microsoft.MicrosoftSSO.get_discovery_document">get_discovery_document</a></code></li>
 <li><code><a title="fastapi_sso.sso.microsoft.MicrosoftSSO.openid_from_response" href="#fastapi_sso.sso.microsoft.MicrosoftSSO.openid_from_response">openid_from_response</a></code></li>
 <li><code><a title="fastapi_sso.sso.microsoft.MicrosoftSSO.provider" href="#fastapi_sso.sso.microsoft.MicrosoftSSO.provider">provider</a></code></li>
-<li><code><a title="fastapi_sso.sso.microsoft.MicrosoftSSO.redirect_uri" href="#fastapi_sso.sso.microsoft.MicrosoftSSO.redirect_uri">redirect_uri</a></code></li>
 <li><code><a title="fastapi_sso.sso.microsoft.MicrosoftSSO.scope" href="#fastapi_sso.sso.microsoft.MicrosoftSSO.scope">scope</a></code></li>
-<li><code><a title="fastapi_sso.sso.microsoft.MicrosoftSSO.state" href="#fastapi_sso.sso.microsoft.MicrosoftSSO.state">state</a></code></li>
 <li><code><a title="fastapi_sso.sso.microsoft.MicrosoftSSO.version" href="#fastapi_sso.sso.microsoft.MicrosoftSSO.version">version</a></code></li>
 </ul>
 </li>

--- a/docs/sso/spotify.html
+++ b/docs/sso/spotify.html
@@ -77,7 +77,7 @@ class SpotifySSO(SSOBase):
 <dl>
 <dt id="fastapi_sso.sso.spotify.SpotifySSO"><code class="flex name class">
 <span>class <span class="ident">SpotifySSO</span></span>
-<span>(</span><span>client_id: str, client_secret: str, redirect_uri: Union[str, NoneType] = None, allow_insecure_http: bool = False, use_state: bool = True)</span>
+<span>(</span><span>client_id: str, client_secret: str, redirect_uri: Optional[str] = None, allow_insecure_http: bool = False, use_state: bool = True)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Class providing login via Spotify OAuth</p></div>
@@ -121,27 +121,11 @@ class SpotifySSO(SSOBase):
 </ul>
 <h3>Class variables</h3>
 <dl>
-<dt id="fastapi_sso.sso.spotify.SpotifySSO.client_id"><code class="name">var <span class="ident">client_id</span> : str</code></dt>
-<dd>
-<div class="desc"></div>
-</dd>
-<dt id="fastapi_sso.sso.spotify.SpotifySSO.client_secret"><code class="name">var <span class="ident">client_secret</span> : str</code></dt>
-<dd>
-<div class="desc"></div>
-</dd>
 <dt id="fastapi_sso.sso.spotify.SpotifySSO.provider"><code class="name">var <span class="ident">provider</span></code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.spotify.SpotifySSO.redirect_uri"><code class="name">var <span class="ident">redirect_uri</span> : Union[str, NoneType]</code></dt>
-<dd>
-<div class="desc"></div>
-</dd>
 <dt id="fastapi_sso.sso.spotify.SpotifySSO.scope"><code class="name">var <span class="ident">scope</span> : List[str]</code></dt>
-<dd>
-<div class="desc"></div>
-</dd>
-<dt id="fastapi_sso.sso.spotify.SpotifySSO.state"><code class="name">var <span class="ident">state</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -229,14 +213,10 @@ async def openid_from_response(cls, response: dict) -&gt; OpenID:
 <li>
 <h4><code><a title="fastapi_sso.sso.spotify.SpotifySSO" href="#fastapi_sso.sso.spotify.SpotifySSO">SpotifySSO</a></code></h4>
 <ul class="">
-<li><code><a title="fastapi_sso.sso.spotify.SpotifySSO.client_id" href="#fastapi_sso.sso.spotify.SpotifySSO.client_id">client_id</a></code></li>
-<li><code><a title="fastapi_sso.sso.spotify.SpotifySSO.client_secret" href="#fastapi_sso.sso.spotify.SpotifySSO.client_secret">client_secret</a></code></li>
 <li><code><a title="fastapi_sso.sso.spotify.SpotifySSO.get_discovery_document" href="#fastapi_sso.sso.spotify.SpotifySSO.get_discovery_document">get_discovery_document</a></code></li>
 <li><code><a title="fastapi_sso.sso.spotify.SpotifySSO.openid_from_response" href="#fastapi_sso.sso.spotify.SpotifySSO.openid_from_response">openid_from_response</a></code></li>
 <li><code><a title="fastapi_sso.sso.spotify.SpotifySSO.provider" href="#fastapi_sso.sso.spotify.SpotifySSO.provider">provider</a></code></li>
-<li><code><a title="fastapi_sso.sso.spotify.SpotifySSO.redirect_uri" href="#fastapi_sso.sso.spotify.SpotifySSO.redirect_uri">redirect_uri</a></code></li>
 <li><code><a title="fastapi_sso.sso.spotify.SpotifySSO.scope" href="#fastapi_sso.sso.spotify.SpotifySSO.scope">scope</a></code></li>
-<li><code><a title="fastapi_sso.sso.spotify.SpotifySSO.state" href="#fastapi_sso.sso.spotify.SpotifySSO.state">state</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/sso/spotify.html
+++ b/docs/sso/spotify.html
@@ -77,7 +77,7 @@ class SpotifySSO(SSOBase):
 <dl>
 <dt id="fastapi_sso.sso.spotify.SpotifySSO"><code class="flex name class">
 <span>class <span class="ident">SpotifySSO</span></span>
-<span>(</span><span>client_id: str, client_secret: str, redirect_uri: str, allow_insecure_http: bool = False, use_state: bool = True)</span>
+<span>(</span><span>client_id: str, client_secret: str, redirect_uri: Union[str, NoneType] = None, allow_insecure_http: bool = False, use_state: bool = True)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Class providing login via Spotify OAuth</p></div>
@@ -133,7 +133,7 @@ class SpotifySSO(SSOBase):
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.spotify.SpotifySSO.redirect_uri"><code class="name">var <span class="ident">redirect_uri</span> : str</code></dt>
+<dt id="fastapi_sso.sso.spotify.SpotifySSO.redirect_uri"><code class="name">var <span class="ident">redirect_uri</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -141,7 +141,7 @@ class SpotifySSO(SSOBase):
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="fastapi_sso.sso.spotify.SpotifySSO.state"><code class="name">var <span class="ident">state</span> : Optional[str]</code></dt>
+<dt id="fastapi_sso.sso.spotify.SpotifySSO.state"><code class="name">var <span class="ident">state</span> : Union[str, NoneType]</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>

--- a/example.py
+++ b/example.py
@@ -1,7 +1,7 @@
 """This is an example usage of fastapi-sso.
 """
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from starlette.requests import Request
 from fastapi_sso.sso.google import GoogleSSO
 
@@ -20,6 +20,8 @@ async def google_login():
 async def google_callback(request: Request):
     """Process login response from Google and return user info"""
     user = await google_sso.verify_and_process(request)
+    if user is None:
+        raise HTTPException(401, "Failed to fetch user information")
     return {
         "id": user.id,
         "picture": user.picture,

--- a/fastapi_sso/__init__.py
+++ b/fastapi_sso/__init__.py
@@ -9,7 +9,7 @@
 \"""This is an example usage of fastapi-sso.
 \"""
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from starlette.requests import Request
 from fastapi_sso.sso.google import GoogleSSO
 
@@ -28,6 +28,8 @@ async def google_login():
 async def google_callback(request: Request):
     \"""Process login response from Google and return user info\"""
     user = await google_sso.verify_and_process(request)
+    if user is None:
+        raise HTTPException(401, "Failed to fetch user information")
     return {
         "id": user.id,
         "picture": user.picture,
@@ -35,5 +37,6 @@ async def google_callback(request: Request):
         "email": user.email,
         "provider": user.provider,
     }
+
 ```
 """

--- a/fastapi_sso/sso/base.py
+++ b/fastapi_sso/sso/base.py
@@ -38,7 +38,7 @@ class SSOBase:
     provider = NotImplemented
     client_id: str = NotImplemented
     client_secret: str = NotImplemented
-    redirect_uri: str = NotImplemented
+    redirect_uri: Optional[str] = NotImplemented
     scope: List[str] = NotImplemented
     _oauth_client: Optional[WebApplicationClient] = None
     state: Optional[str] = None
@@ -47,10 +47,11 @@ class SSOBase:
         self,
         client_id: str,
         client_secret: str,
-        redirect_uri: str,
+        redirect_uri: Optional[str] = None,
         allow_insecure_http: bool = False,
         use_state: bool = True,
     ):
+        # pylint: disable=too-many-arguments
         self.client_id = client_id
         self.client_secret = client_secret
         self.redirect_uri = redirect_uri
@@ -99,22 +100,27 @@ class SSOBase:
         discovery = await self.get_discovery_document()
         return discovery.get("userinfo_endpoint")
 
-    async def get_login_url(self) -> str:
+    async def get_login_url(self, redirect_uri: Optional[str] = None) -> str:
         """Return prepared login url. This is low-level, see {get_login_redirect} instead."""
+        if redirect_uri is None:
+            if self.redirect_uri is None:
+                raise ValueError("redirect_uri must be provided, either at construction or request time")
+            redirect_uri = self.redirect_uri
+
         if self.use_state:
             self.state = str(uuid4())
         request_uri = self.oauth_client.prepare_request_uri(
-            await self.authorization_endpoint, redirect_uri=self.redirect_uri, state=self.state, scope=self.scope
+            await self.authorization_endpoint, redirect_uri=redirect_uri, state=self.state, scope=self.scope
         )
         return request_uri
 
-    async def get_login_redirect(self) -> RedirectResponse:
+    async def get_login_redirect(self, redirect_uri: Optional[str] = None) -> RedirectResponse:
         """Return redirect response by Stalette to login page of Oauth SSO provider
 
         Returns:
             RedirectResponse -- Starlette response (may directly be returned from FastAPI)
         """
-        login_uri = await self.get_login_url()
+        login_uri = await self.get_login_url(redirect_uri=redirect_uri)
         response = RedirectResponse(login_uri, 303)
         if self.state is not None and self.use_state:
             response.set_cookie("ssostate", self.state, expires=600)
@@ -147,6 +153,7 @@ class SSOBase:
         """This method should be called from callback endpoint to verify the user and request user info endpoint.
         This is low level, you should use {verify_and_process} instead.
         """
+        # pylint: disable=too-many-locals
         url = request.url
         scheme = url.scheme
         if not self.allow_insecure_http and scheme != "https":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-sso"
-version = "0.2.13"
+version = "0.3.0"
 description = "FastAPI plugin to enable SSO to most common providers (such as Facebook login, Google login and login via Microsoft Office 365 Account)"
 authors = ["Tomas Votava <info@tomasvotava.eu>"]
 readme = "README.md"


### PR DESCRIPTION
Resolves #11.

redirect_uri becomes an optional parameter to the SSOBase constructor, defaulting to None.
redirect_uri is added as an optional parameter to get_login_url() and get_login_redirect();
if provided, it will override any value provided at construct time.

This allows code to work properly when it may run in multiple host environments (e.g., http://localhost:8000
and https://mydomain.com), or when it is running behind a reverse proxy like nginx and the
base url is not known until request time.

The API changes are backward-compatible so existing users should not be affected.

The examples and documentation are updated to show the new calling convention, which
is insensitive to host base URL.

Also includes a couple of very minor edits to suppress two pylint warnings that were present
before this commit.