### PR TITLE
Allow extra fields for `OpenID`

### DIFF
--- a/fastapi_sso/sso/base.py
+++ b/fastapi_sso/sso/base.py
@@ -40,6 +40,9 @@ class OpenID(pydantic.BaseModel):  # pylint: disable=no-member
     display_name: Optional[str] = None
     picture: Optional[str] = None
     provider: Optional[str] = None
+        
+    class Config:
+        extra = "allow"
 
 
 # pylint: disable=too-many-instance-attributes


### PR DESCRIPTION
Allows additional fields to the `OpenId` model. Addresses issues mentioned in https://github.com/tomasvotava/fastapi-sso/issues/30