### PR TITLE
Add gitlab access

### DIFF
--- a/examples/gitlab.py
+++ b/examples/gitlab.py
@@ -1,0 +1,37 @@
+"""Github Login Example
+"""
+
+import os
+import uvicorn
+from fastapi import FastAPI, Request
+from fastapi_sso.sso.gitlab import GitlabSSO
+
+os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = "1"
+CLIENT_ID = os.environ["CLIENT_ID"]
+CLIENT_SECRET = os.environ["CLIENT_SECRET"]
+
+app = FastAPI()
+
+sso = GitlabSSO(
+    client_id=CLIENT_ID,
+    client_secret=CLIENT_SECRET,
+    redirect_uri="http://localhost:5000/auth/callback",
+    allow_insecure_http=True,
+)
+
+
+@app.get("/auth/login")
+async def auth_init():
+    """Initialize auth and redirect"""
+    return await sso.get_login_redirect()
+
+
+@app.get("/auth/callback")
+async def auth_callback(request: Request):
+    """Verify login"""
+    user = await sso.verify_and_process(request)
+    return user
+
+
+if __name__ == "__main__":
+    uvicorn.run(app="examples.github:app", host="127.0.0.1", port=5000)

--- a/examples/gitlab.py
+++ b/examples/gitlab.py
@@ -34,4 +34,4 @@ async def auth_callback(request: Request):
 
 
 if __name__ == "__main__":
-    uvicorn.run(app="examples.github:app", host="127.0.0.1", port=5000)
+    uvicorn.run(app="examples.gitlab:app", host="127.0.0.1", port=5000)

--- a/fastapi_sso/sso/gitlab.py
+++ b/fastapi_sso/sso/gitlab.py
@@ -1,0 +1,28 @@
+"""Gitlab SSO Oauth Helper class"""
+
+from fastapi_sso.sso.base import DiscoveryDocument, OpenID, SSOBase
+
+
+class GitlabSSO(SSOBase):
+    """Class providing login via Gitlab SSO"""
+
+    provider = "gitlab"
+    scope = ["read_user"]
+    additional_headers = {"accept": "application/json"}
+
+    async def get_discovery_document(self) -> DiscoveryDocument:
+        return {
+            "authorization_endpoint": "https://gitlab.com/oauth/authorize",
+            "token_endpoint": "https://gitlab.com/oauth/token",
+            "userinfo_endpoint": "https://gitlab.com/api/v4/user",
+        }
+
+    @classmethod
+    async def openid_from_response(cls, response: dict) -> OpenID:
+        return OpenID(
+            email=response["email"],
+            provider=cls.provider,
+            id=response["id"],
+            display_name=response["login"],
+            picture=response["avatar_url"],
+        )

--- a/fastapi_sso/sso/gitlab.py
+++ b/fastapi_sso/sso/gitlab.py
@@ -7,7 +7,7 @@ class GitlabSSO(SSOBase):
     """Class providing login via Gitlab SSO"""
 
     provider = "gitlab"
-    scope = ["read_user"]
+    scope = ["read_user", "openid", "profile"]
     additional_headers = {"accept": "application/json"}
 
     async def get_discovery_document(self) -> DiscoveryDocument:
@@ -23,6 +23,6 @@ class GitlabSSO(SSOBase):
             email=response["email"],
             provider=cls.provider,
             id=response["id"],
-            display_name=response["login"],
+            display_name=response["username"],
             picture=response["avatar_url"],
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-sso"
-version = "0.6.4"
+version = "0.6.5"
 description = "FastAPI plugin to enable SSO to most common providers (such as Facebook login, Google login and login via Microsoft Office 365 Account)"
 authors = ["Tomas Votava <info@tomasvotava.eu>"]
 readme = "README.md"


### PR DESCRIPTION
Add GitlabSSO class in order to use GitLab as SSO.
It requires some scopes like 'read_user', 'openid' and 'profile' to retrieves information like username and avatar_url.