### PR TITLE
Convert type of GitHub id (int) to OpenID id (str)

### DIFF
--- a/docs/sso/github.html
+++ b/docs/sso/github.html
@@ -51,7 +51,7 @@ class GithubSSO(SSOBase):
         return OpenID(
             email=response[&#34;email&#34;],
             provider=cls.provider,
-            id=response[&#34;id&#34;],
+            id=str(response[&#34;id&#34;]),
             display_name=response[&#34;login&#34;],
             picture=response[&#34;avatar_url&#34;],
         )</code></pre>
@@ -95,7 +95,7 @@ class GithubSSO(SSOBase):
         return OpenID(
             email=response[&#34;email&#34;],
             provider=cls.provider,
-            id=response[&#34;id&#34;],
+            id=str(response[&#34;id&#34;]),
             display_name=response[&#34;login&#34;],
             picture=response[&#34;avatar_url&#34;],
         )</code></pre>

--- a/fastapi_sso/sso/github.py
+++ b/fastapi_sso/sso/github.py
@@ -22,7 +22,7 @@ class GithubSSO(SSOBase):
         return OpenID(
             email=response["email"],
             provider=cls.provider,
-            id=response["id"],
+            id=str(response["id"]),
             display_name=response["login"],
             picture=response["avatar_url"],
         )


### PR DESCRIPTION
The OpenID model in fastapi-sso expects a str, but the 'id' field provided by GitHub at the /user endpoint is, by 'Response Schema', an integer; see
https://docs.github.com/en/free-pro-team@latest/rest/users/users?apiVersion=2022-11-28#get-the-authenticated-user

In pydantic v2 (used in fastapi 0.100.0), this throws a validation error, breaking the Github SSO class right now.

This commit fixes the issue by casting it to str

Fixes #45