### PR TITLE
A clean solution to "allow setting additional data for OpenID model" (issue #30)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# IDEs
+.idea

--- a/docs/sso/base.html
+++ b/docs/sso/base.html
@@ -34,6 +34,7 @@
 import json
 import sys
 import warnings
+from collections.abc import Mapping
 from types import TracebackType
 from typing import Any, Dict, List, Optional, Type
 
@@ -78,6 +79,7 @@ class OpenID(pydantic.BaseModel):  # pylint: disable=no-member
     display_name: Optional[str] = None
     picture: Optional[str] = None
     provider: Optional[str] = None
+    data: Optional[Mapping[str, Any]] = None
 
 
 # pylint: disable=too-many-instance-attributes
@@ -390,7 +392,8 @@ allow <code>self</code> as a field name.</p></div>
     last_name: Optional[str] = None
     display_name: Optional[str] = None
     picture: Optional[str] = None
-    provider: Optional[str] = None</code></pre>
+    provider: Optional[str] = None
+    data: Optional[Mapping[str, Any]] = None</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">
@@ -398,6 +401,10 @@ allow <code>self</code> as a field name.</p></div>
 </ul>
 <h3>Class variables</h3>
 <dl>
+<dt id="fastapi_sso.sso.base.OpenID.data"><code class="name">var <span class="ident">data</span> : Optional[collections.abc.Mapping[str, typing.Any]]</code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
 <dt id="fastapi_sso.sso.base.OpenID.display_name"><code class="name">var <span class="ident">display_name</span> : Optional[str]</code></dt>
 <dd>
 <div class="desc"></div>
@@ -1147,6 +1154,7 @@ params {Optional[Dict[str, Any]]} &ndash; Optional additional query parameters t
 <li>
 <h4><code><a title="fastapi_sso.sso.base.OpenID" href="#fastapi_sso.sso.base.OpenID">OpenID</a></code></h4>
 <ul class="two-column">
+<li><code><a title="fastapi_sso.sso.base.OpenID.data" href="#fastapi_sso.sso.base.OpenID.data">data</a></code></li>
 <li><code><a title="fastapi_sso.sso.base.OpenID.display_name" href="#fastapi_sso.sso.base.OpenID.display_name">display_name</a></code></li>
 <li><code><a title="fastapi_sso.sso.base.OpenID.email" href="#fastapi_sso.sso.base.OpenID.email">email</a></code></li>
 <li><code><a title="fastapi_sso.sso.base.OpenID.first_name" href="#fastapi_sso.sso.base.OpenID.first_name">first_name</a></code></li>

--- a/docs/sso/facebook.html
+++ b/docs/sso/facebook.html
@@ -59,6 +59,7 @@ class FacebookSSO(SSOBase):
             provider=cls.provider,
             id=response.get(&#34;id&#34;),
             picture=response.get(&#34;picture&#34;, {}).get(&#34;data&#34;, {}).get(&#34;url&#34;, None),
+            data=response,
         )</code></pre>
 </details>
 </section>
@@ -107,6 +108,7 @@ class FacebookSSO(SSOBase):
             provider=cls.provider,
             id=response.get(&#34;id&#34;),
             picture=response.get(&#34;picture&#34;, {}).get(&#34;data&#34;, {}).get(&#34;url&#34;, None),
+            data=response,
         )</code></pre>
 </details>
 <h3>Ancestors</h3>
@@ -150,6 +152,7 @@ async def openid_from_response(cls, response: dict) -&gt; OpenID:
         provider=cls.provider,
         id=response.get(&#34;id&#34;),
         picture=response.get(&#34;picture&#34;, {}).get(&#34;data&#34;, {}).get(&#34;url&#34;, None),
+        data=response,
     )</code></pre>
 </details>
 </dd>

--- a/docs/sso/fitbit.html
+++ b/docs/sso/fitbit.html
@@ -51,6 +51,7 @@ class FitbitSSO(SSOBase):
             display_name=info[&#34;displayName&#34;],
             picture=info[&#34;avatar&#34;],
             provider=cls.provider,
+            data=response,
         )
 
     async def get_discovery_document(self) -&gt; DiscoveryDocument:
@@ -99,6 +100,7 @@ class FitbitSSO(SSOBase):
             display_name=info[&#34;displayName&#34;],
             picture=info[&#34;avatar&#34;],
             provider=cls.provider,
+            data=response,
         )
 
     async def get_discovery_document(self) -&gt; DiscoveryDocument:
@@ -147,6 +149,7 @@ async def openid_from_response(cls, response: dict) -&gt; OpenID:
         display_name=info[&#34;displayName&#34;],
         picture=info[&#34;avatar&#34;],
         provider=cls.provider,
+        data=response,
     )</code></pre>
 </details>
 </dd>

--- a/docs/sso/generic.html
+++ b/docs/sso/generic.html
@@ -98,6 +98,7 @@ def create_provider(
                 logger.warning(&#34;No response convertor was provided, returned OpenID will always be empty&#34;)
                 return OpenID(
                     provider=cls.provider,
+                    data=response,
                 )
             return response_convertor(response)
 
@@ -207,6 +208,7 @@ sso = SSOProvider(
                 logger.warning(&#34;No response convertor was provided, returned OpenID will always be empty&#34;)
                 return OpenID(
                     provider=cls.provider,
+                    data=response,
                 )
             return response_convertor(response)
 

--- a/docs/sso/github.html
+++ b/docs/sso/github.html
@@ -54,6 +54,7 @@ class GithubSSO(SSOBase):
             id=str(response[&#34;id&#34;]),
             display_name=response[&#34;login&#34;],
             picture=response[&#34;avatar_url&#34;],
+            data=response,
         )</code></pre>
 </details>
 </section>
@@ -98,6 +99,7 @@ class GithubSSO(SSOBase):
             id=str(response[&#34;id&#34;]),
             display_name=response[&#34;login&#34;],
             picture=response[&#34;avatar_url&#34;],
+            data=response,
         )</code></pre>
 </details>
 <h3>Ancestors</h3>

--- a/docs/sso/gitlab.html
+++ b/docs/sso/gitlab.html
@@ -54,6 +54,7 @@ class GitlabSSO(SSOBase):
             id=response[&#34;id&#34;],
             display_name=response[&#34;username&#34;],
             picture=response[&#34;avatar_url&#34;],
+            data=response,
         )</code></pre>
 </details>
 </section>
@@ -98,6 +99,7 @@ class GitlabSSO(SSOBase):
             id=response[&#34;id&#34;],
             display_name=response[&#34;username&#34;],
             picture=response[&#34;avatar_url&#34;],
+            data=response,
         )</code></pre>
 </details>
 <h3>Ancestors</h3>

--- a/docs/sso/google.html
+++ b/docs/sso/google.html
@@ -54,6 +54,7 @@ class GoogleSSO(SSOBase):
                 last_name=response.get(&#34;family_name&#34;),
                 display_name=response.get(&#34;name&#34;),
                 picture=response.get(&#34;picture&#34;),
+                data=response,
             )
         raise SSOLoginError(401, f&#34;User {response.get(&#39;email&#39;)} is not verified with Google&#34;)
 
@@ -103,6 +104,7 @@ class GoogleSSO(SSOBase):
                 last_name=response.get(&#34;family_name&#34;),
                 display_name=response.get(&#34;name&#34;),
                 picture=response.get(&#34;picture&#34;),
+                data=response,
             )
         raise SSOLoginError(401, f&#34;User {response.get(&#39;email&#39;)} is not verified with Google&#34;)
 
@@ -155,6 +157,7 @@ async def openid_from_response(cls, response: dict) -&gt; OpenID:
             last_name=response.get(&#34;family_name&#34;),
             display_name=response.get(&#34;name&#34;),
             picture=response.get(&#34;picture&#34;),
+            data=response,
         )
     raise SSOLoginError(401, f&#34;User {response.get(&#39;email&#39;)} is not verified with Google&#34;)</code></pre>
 </details>

--- a/docs/sso/kakao.html
+++ b/docs/sso/kakao.html
@@ -49,7 +49,11 @@ class KakaoSSO(SSOBase):
 
     @classmethod
     async def openid_from_response(cls, response: dict) -&gt; OpenID:
-        return OpenID(display_name=response[&#34;properties&#34;][&#34;nickname&#34;], provider=cls.provider)</code></pre>
+        return OpenID(
+            display_name=response[&#34;properties&#34;][&#34;nickname&#34;],
+            provider=cls.provider,
+            data=response,
+        )</code></pre>
 </details>
 </section>
 <section>
@@ -87,7 +91,11 @@ class KakaoSSO(SSOBase):
 
     @classmethod
     async def openid_from_response(cls, response: dict) -&gt; OpenID:
-        return OpenID(display_name=response[&#34;properties&#34;][&#34;nickname&#34;], provider=cls.provider)</code></pre>
+        return OpenID(
+            display_name=response[&#34;properties&#34;][&#34;nickname&#34;],
+            provider=cls.provider,
+            data=response,
+        )</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">

--- a/docs/sso/microsoft.html
+++ b/docs/sso/microsoft.html
@@ -38,7 +38,7 @@ class MicrosoftSSO(SSOBase):
     &#34;&#34;&#34;Class providing login using Microsoft OAuth&#34;&#34;&#34;
 
     provider = &#34;microsoft&#34;
-    scope = [&#34;openid&#34;]
+    scope = [&#34;openid&#34;, &#34;User.Read&#34;]
     version = &#34;v1.0&#34;
     tenant: str = &#34;common&#34;
 
@@ -71,7 +71,15 @@ class MicrosoftSSO(SSOBase):
 
     @classmethod
     async def openid_from_response(cls, response: dict) -&gt; OpenID:
-        return OpenID(email=response[&#34;mail&#34;], display_name=response[&#34;displayName&#34;], provider=cls.provider)</code></pre>
+        return OpenID(
+            email=response[&#34;mail&#34;],
+            display_name=response[&#34;displayName&#34;],
+            provider=cls.provider,
+            id=response.get(&#34;id&#34;),
+            first_name=response.get(&#34;givenName&#34;),
+            last_name=response.get(&#34;surname&#34;),
+            data=response,
+        )</code></pre>
 </details>
 </section>
 <section>
@@ -97,7 +105,7 @@ class MicrosoftSSO(SSOBase):
     &#34;&#34;&#34;Class providing login using Microsoft OAuth&#34;&#34;&#34;
 
     provider = &#34;microsoft&#34;
-    scope = [&#34;openid&#34;]
+    scope = [&#34;openid&#34;, &#34;User.Read&#34;]
     version = &#34;v1.0&#34;
     tenant: str = &#34;common&#34;
 
@@ -130,7 +138,15 @@ class MicrosoftSSO(SSOBase):
 
     @classmethod
     async def openid_from_response(cls, response: dict) -&gt; OpenID:
-        return OpenID(email=response[&#34;mail&#34;], display_name=response[&#34;displayName&#34;], provider=cls.provider)</code></pre>
+        return OpenID(
+            email=response[&#34;mail&#34;],
+            display_name=response[&#34;displayName&#34;],
+            provider=cls.provider,
+            id=response.get(&#34;id&#34;),
+            first_name=response.get(&#34;givenName&#34;),
+            last_name=response.get(&#34;surname&#34;),
+            data=response,
+        )</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">

--- a/docs/sso/naver.html
+++ b/docs/sso/naver.html
@@ -50,7 +50,11 @@ class NaverSSO(SSOBase):
 
     @classmethod
     async def openid_from_response(cls, response: dict) -&gt; OpenID:
-        return OpenID(display_name=response[&#34;properties&#34;][&#34;nickname&#34;], provider=cls.provider)</code></pre>
+        return OpenID(
+            display_name=response[&#34;properties&#34;][&#34;nickname&#34;],
+            provider=cls.provider,
+            data=response,
+        )</code></pre>
 </details>
 </section>
 <section>
@@ -88,7 +92,11 @@ class NaverSSO(SSOBase):
 
     @classmethod
     async def openid_from_response(cls, response: dict) -&gt; OpenID:
-        return OpenID(display_name=response[&#34;properties&#34;][&#34;nickname&#34;], provider=cls.provider)</code></pre>
+        return OpenID(
+            display_name=response[&#34;properties&#34;][&#34;nickname&#34;],
+            provider=cls.provider,
+            data=response,
+        )</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">

--- a/docs/sso/spotify.html
+++ b/docs/sso/spotify.html
@@ -61,6 +61,7 @@ class SpotifySSO(SSOBase):
             provider=cls.provider,
             id=response.get(&#34;id&#34;),
             picture=picture,
+            data=response,
         )</code></pre>
 </details>
 </section>
@@ -110,6 +111,7 @@ class SpotifySSO(SSOBase):
             provider=cls.provider,
             id=response.get(&#34;id&#34;),
             picture=picture,
+            data=response,
         )</code></pre>
 </details>
 <h3>Ancestors</h3>
@@ -151,6 +153,7 @@ async def openid_from_response(cls, response: dict) -&gt; OpenID:
         provider=cls.provider,
         id=response.get(&#34;id&#34;),
         picture=picture,
+        data=response,
     )</code></pre>
 </details>
 </dd>

--- a/fastapi_sso/sso/base.py
+++ b/fastapi_sso/sso/base.py
@@ -5,6 +5,7 @@
 import json
 import sys
 import warnings
+from collections.abc import Mapping
 from types import TracebackType
 from typing import Any, Dict, List, Optional, Type
 
@@ -49,6 +50,7 @@ class OpenID(pydantic.BaseModel):  # pylint: disable=no-member
     display_name: Optional[str] = None
     picture: Optional[str] = None
     provider: Optional[str] = None
+    data: Optional[Mapping[str, Any]] = None
 
 
 # pylint: disable=too-many-instance-attributes

--- a/fastapi_sso/sso/facebook.py
+++ b/fastapi_sso/sso/facebook.py
@@ -30,4 +30,5 @@ class FacebookSSO(SSOBase):
             provider=cls.provider,
             id=response.get("id"),
             picture=response.get("picture", {}).get("data", {}).get("url", None),
+            data=response,
         )

--- a/fastapi_sso/sso/fitbit.py
+++ b/fastapi_sso/sso/fitbit.py
@@ -22,6 +22,7 @@ class FitbitSSO(SSOBase):
             display_name=info["displayName"],
             picture=info["avatar"],
             provider=cls.provider,
+            data=response,
         )
 
     async def get_discovery_document(self) -> DiscoveryDocument:

--- a/fastapi_sso/sso/generic.py
+++ b/fastapi_sso/sso/generic.py
@@ -67,6 +67,7 @@ def create_provider(
                 logger.warning("No response convertor was provided, returned OpenID will always be empty")
                 return OpenID(
                     provider=cls.provider,
+                    data=response,
                 )
             return response_convertor(response)
 

--- a/fastapi_sso/sso/github.py
+++ b/fastapi_sso/sso/github.py
@@ -25,4 +25,5 @@ class GithubSSO(SSOBase):
             id=str(response["id"]),
             display_name=response["login"],
             picture=response["avatar_url"],
+            data=response,
         )

--- a/fastapi_sso/sso/gitlab.py
+++ b/fastapi_sso/sso/gitlab.py
@@ -25,4 +25,5 @@ class GitlabSSO(SSOBase):
             id=response["id"],
             display_name=response["username"],
             picture=response["avatar_url"],
+            data=response,
         )

--- a/fastapi_sso/sso/google.py
+++ b/fastapi_sso/sso/google.py
@@ -25,6 +25,7 @@ class GoogleSSO(SSOBase):
                 last_name=response.get("family_name"),
                 display_name=response.get("name"),
                 picture=response.get("picture"),
+                data=response,
             )
         raise SSOLoginError(401, f"User {response.get('email')} is not verified with Google")
 

--- a/fastapi_sso/sso/kakao.py
+++ b/fastapi_sso/sso/kakao.py
@@ -20,4 +20,8 @@ class KakaoSSO(SSOBase):
 
     @classmethod
     async def openid_from_response(cls, response: dict) -> OpenID:
-        return OpenID(display_name=response["properties"]["nickname"], provider=cls.provider)
+        return OpenID(
+            display_name=response["properties"]["nickname"],
+            provider=cls.provider,
+            data=response,
+        )

--- a/fastapi_sso/sso/microsoft.py
+++ b/fastapi_sso/sso/microsoft.py
@@ -49,4 +49,5 @@ class MicrosoftSSO(SSOBase):
             id=response.get("id"),
             first_name=response.get("givenName"),
             last_name=response.get("surname"),
+            data=response,
         )

--- a/fastapi_sso/sso/naver.py
+++ b/fastapi_sso/sso/naver.py
@@ -21,4 +21,8 @@ class NaverSSO(SSOBase):
 
     @classmethod
     async def openid_from_response(cls, response: dict) -> OpenID:
-        return OpenID(display_name=response["properties"]["nickname"], provider=cls.provider)
+        return OpenID(
+            display_name=response["properties"]["nickname"],
+            provider=cls.provider,
+            data=response,
+        )

--- a/fastapi_sso/sso/spotify.py
+++ b/fastapi_sso/sso/spotify.py
@@ -32,4 +32,5 @@ class SpotifySSO(SSOBase):
             provider=cls.provider,
             id=response.get("id"),
             picture=picture,
+            data=response,
         )

--- a/tests/test_generic_provider.py
+++ b/tests/test_generic_provider.py
@@ -32,13 +32,22 @@ class TestGenericProvider:
         Provider = create_provider(
             discovery_document=DISCOVERY,
             response_convertor=lambda response: OpenID(
-                id=response["id"], email=response["email"], display_name=response["display_name"]
+                id=response["id"],
+                email=response["email"],
+                display_name=response["display_name"],
+                data={"gibberish": "lorem ipsum"},
             ),
         )
         sso = Provider("client_id", "client_secret")
-        openid_response = {"id": "test", "email": "email@example.com", "display_name": "Test"}
+        openid_response = {
+            "id": "test",
+            "email": "email@example.com",
+            "display_name": "Test",
+            "data": {"gibberish": "lorem ipsum"}
+        }
         openid = await sso.openid_from_response(openid_response)
         assert openid.provider is None
         assert openid.id == openid_response["id"]
         assert openid.email == openid_response["email"]
         assert openid.display_name == openid_response["display_name"]
+        assert openid.data == openid_response["data"]


### PR DESCRIPTION
I added an extra `data` field that contains all of the returned JSON values. I think this is probably the cleanest solution. Let me know if you want any edits.

- feat: allow setting additional data for OpenID model
- docs: add data field
