### PR TITLE
feat: make `openid_from_response` into an instance method

### DIFF
--- a/fastapi_sso/sso/base.py
+++ b/fastapi_sso/sso/base.py
@@ -120,10 +120,9 @@ class SSOBase:
         """Get refresh token (if returned from provider)"""
         return self._refresh_token or self.oauth_client.refresh_token
 
-    @classmethod
-    async def openid_from_response(cls, response: dict) -> OpenID:
+    async def openid_from_response(self, response: dict, session: Optional[httpx.AsyncClient] = None) -> OpenID:
         """Return {OpenID} object from provider's user info endpoint response"""
-        raise NotImplementedError(f"Provider {cls.provider} not supported")
+        raise NotImplementedError(f"Provider {self.provider} not supported")
 
     async def get_discovery_document(self) -> DiscoveryDocument:
         """Get discovery document containing handy urls"""
@@ -289,4 +288,4 @@ class SSOBase:
             response = await session.get(uri, headers=headers)
             content = response.json()
 
-        return await self.openid_from_response(content)
+        return await self.openid_from_response(content, session)

--- a/fastapi_sso/sso/facebook.py
+++ b/fastapi_sso/sso/facebook.py
@@ -1,7 +1,12 @@
 """Facebook SSO Login Helper
 """
 
+from typing import TYPE_CHECKING, Optional
+
 from fastapi_sso.sso.base import DiscoveryDocument, OpenID, SSOBase
+
+if TYPE_CHECKING:
+    import httpx
 
 
 class FacebookSSO(SSOBase):
@@ -19,15 +24,14 @@ class FacebookSSO(SSOBase):
             "userinfo_endpoint": f"{self.base_url}/me?fields=id,name,email,first_name,last_name,picture",
         }
 
-    @classmethod
-    async def openid_from_response(cls, response: dict) -> OpenID:
+    async def openid_from_response(self, response: dict, session: Optional["httpx.AsyncClient"] = None) -> OpenID:
         """Return OpenID from user information provided by Facebook"""
         return OpenID(
             email=response.get("email", ""),
             first_name=response.get("first_name"),
             last_name=response.get("last_name"),
             display_name=response.get("name"),
-            provider=cls.provider,
+            provider=self.provider,
             id=response.get("id"),
             picture=response.get("picture", {}).get("data", {}).get("url", None),
         )

--- a/fastapi_sso/sso/fitbit.py
+++ b/fastapi_sso/sso/fitbit.py
@@ -1,7 +1,12 @@
 """Fitbit OAuth Login Helper
 """
 
+from typing import TYPE_CHECKING, Optional
+
 from fastapi_sso.sso.base import DiscoveryDocument, OpenID, SSOBase, SSOLoginError
+
+if TYPE_CHECKING:
+    import httpx
 
 
 class FitbitSSO(SSOBase):
@@ -10,8 +15,7 @@ class FitbitSSO(SSOBase):
     provider = "fitbit"
     scope = ["profile"]
 
-    @classmethod
-    async def openid_from_response(cls, response: dict) -> OpenID:
+    async def openid_from_response(self, response: dict, session: Optional["httpx.AsyncClient"] = None) -> OpenID:
         """Return OpenID from user information provided by Google"""
         info = response.get("user")
         if not info:
@@ -21,7 +25,7 @@ class FitbitSSO(SSOBase):
             first_name=info["fullName"],
             display_name=info["displayName"],
             picture=info["avatar"],
-            provider=cls.provider,
+            provider=self.provider,
         )
 
     async def get_discovery_document(self) -> DiscoveryDocument:

--- a/fastapi_sso/sso/github.py
+++ b/fastapi_sso/sso/github.py
@@ -1,6 +1,11 @@
 """Github SSO Oauth Helper class"""
 
+from typing import TYPE_CHECKING, Optional
+
 from fastapi_sso.sso.base import DiscoveryDocument, OpenID, SSOBase
+
+if TYPE_CHECKING:
+    import httpx
 
 
 class GithubSSO(SSOBase):
@@ -17,11 +22,10 @@ class GithubSSO(SSOBase):
             "userinfo_endpoint": "https://api.github.com/user",
         }
 
-    @classmethod
-    async def openid_from_response(cls, response: dict) -> OpenID:
+    async def openid_from_response(self, response: dict, session: Optional["httpx.AsyncClient"] = None) -> OpenID:
         return OpenID(
             email=response["email"],
-            provider=cls.provider,
+            provider=self.provider,
             id=str(response["id"]),
             display_name=response["login"],
             picture=response["avatar_url"],

--- a/fastapi_sso/sso/gitlab.py
+++ b/fastapi_sso/sso/gitlab.py
@@ -1,6 +1,11 @@
 """Gitlab SSO Oauth Helper class"""
 
+from typing import TYPE_CHECKING, Optional
+
 from fastapi_sso.sso.base import DiscoveryDocument, OpenID, SSOBase
+
+if TYPE_CHECKING:
+    import httpx
 
 
 class GitlabSSO(SSOBase):
@@ -17,11 +22,10 @@ class GitlabSSO(SSOBase):
             "userinfo_endpoint": "https://gitlab.com/api/v4/user",
         }
 
-    @classmethod
-    async def openid_from_response(cls, response: dict) -> OpenID:
+    async def openid_from_response(self, response: dict, session: Optional["httpx.AsyncClient"] = None) -> OpenID:
         return OpenID(
             email=response["email"],
-            provider=cls.provider,
+            provider=self.provider,
             id=response["id"],
             display_name=response["username"],
             picture=response["avatar_url"],

--- a/fastapi_sso/sso/google.py
+++ b/fastapi_sso/sso/google.py
@@ -1,6 +1,8 @@
 """Google SSO Login Helper
 """
 
+from typing import Optional
+
 import httpx
 
 from fastapi_sso.sso.base import DiscoveryDocument, OpenID, SSOBase, SSOLoginError
@@ -13,13 +15,12 @@ class GoogleSSO(SSOBase):
     provider = "google"
     scope = ["openid", "email", "profile"]
 
-    @classmethod
-    async def openid_from_response(cls, response: dict) -> OpenID:
+    async def openid_from_response(self, response: dict, session: Optional["httpx.AsyncClient"] = None) -> OpenID:
         """Return OpenID from user information provided by Google"""
         if response.get("email_verified"):
             return OpenID(
                 email=response.get("email", ""),
-                provider=cls.provider,
+                provider=self.provider,
                 id=response.get("sub"),
                 first_name=response.get("given_name"),
                 last_name=response.get("family_name"),

--- a/fastapi_sso/sso/kakao.py
+++ b/fastapi_sso/sso/kakao.py
@@ -1,7 +1,11 @@
 """Kakao SSO Oauth Helper class"""
 
+from typing import TYPE_CHECKING, Optional
 
 from fastapi_sso.sso.base import DiscoveryDocument, OpenID, SSOBase
+
+if TYPE_CHECKING:
+    import httpx
 
 
 class KakaoSSO(SSOBase):
@@ -18,6 +22,5 @@ class KakaoSSO(SSOBase):
             "userinfo_endpoint": f"https://kapi.kakao.com/{self.version}/user/me",
         }
 
-    @classmethod
-    async def openid_from_response(cls, response: dict) -> OpenID:
-        return OpenID(display_name=response["properties"]["nickname"], provider=cls.provider)
+    async def openid_from_response(self, response: dict, session: Optional["httpx.AsyncClient"] = None) -> OpenID:
+        return OpenID(display_name=response["properties"]["nickname"], provider=self.provider)

--- a/fastapi_sso/sso/microsoft.py
+++ b/fastapi_sso/sso/microsoft.py
@@ -1,8 +1,11 @@
 """Microsoft SSO Oauth Helper class"""
 
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from fastapi_sso.sso.base import DiscoveryDocument, OpenID, SSOBase
+
+if TYPE_CHECKING:
+    import httpx
 
 
 class MicrosoftSSO(SSOBase):
@@ -40,12 +43,11 @@ class MicrosoftSSO(SSOBase):
             "userinfo_endpoint": f"https://graph.microsoft.com/{self.version}/me",
         }
 
-    @classmethod
-    async def openid_from_response(cls, response: dict) -> OpenID:
+    async def openid_from_response(self, response: dict, session: Optional["httpx.AsyncClient"] = None) -> OpenID:
         return OpenID(
             email=response["mail"],
             display_name=response["displayName"],
-            provider=cls.provider,
+            provider=self.provider,
             id=response.get("id"),
             first_name=response.get("givenName"),
             last_name=response.get("surname"),

--- a/fastapi_sso/sso/naver.py
+++ b/fastapi_sso/sso/naver.py
@@ -1,8 +1,11 @@
 """Naver SSO Oauth Helper class"""
 
-from typing import List
+from typing import TYPE_CHECKING, List, Optional
 
 from fastapi_sso.sso.base import DiscoveryDocument, OpenID, SSOBase
+
+if TYPE_CHECKING:
+    import httpx
 
 
 class NaverSSO(SSOBase):
@@ -19,6 +22,5 @@ class NaverSSO(SSOBase):
             "userinfo_endpoint": "https://openapi.naver.com/v1/nid/me",
         }
 
-    @classmethod
-    async def openid_from_response(cls, response: dict) -> OpenID:
-        return OpenID(display_name=response["properties"]["nickname"], provider=cls.provider)
+    async def openid_from_response(self, response: dict, session: Optional["httpx.AsyncClient"] = None) -> OpenID:
+        return OpenID(display_name=response["properties"]["nickname"], provider=self.provider)

--- a/fastapi_sso/sso/spotify.py
+++ b/fastapi_sso/sso/spotify.py
@@ -2,7 +2,12 @@
 """
 
 
+from typing import TYPE_CHECKING, Optional
+
 from fastapi_sso.sso.base import DiscoveryDocument, OpenID, SSOBase
+
+if TYPE_CHECKING:
+    import httpx
 
 
 class SpotifySSO(SSOBase):
@@ -19,8 +24,7 @@ class SpotifySSO(SSOBase):
             "userinfo_endpoint": "https://api.spotify.com/v1/me",
         }
 
-    @classmethod
-    async def openid_from_response(cls, response: dict) -> OpenID:
+    async def openid_from_response(self, response: dict, session: Optional["httpx.AsyncClient"] = None) -> OpenID:
         """Return OpenID from user information provided by Spotify"""
         if response.get("images", []):
             picture = response["images"][0]["url"]
@@ -29,7 +33,7 @@ class SpotifySSO(SSOBase):
         return OpenID(
             email=response.get("email", ""),
             display_name=response.get("display_name"),
-            provider=cls.provider,
+            provider=self.provider,
             id=response.get("id"),
             picture=picture,
         )

--- a/tests/test_generic_provider.py
+++ b/tests/test_generic_provider.py
@@ -31,7 +31,7 @@ class TestGenericProvider:
     async def test_response_convertor(self):
         Provider = create_provider(
             discovery_document=DISCOVERY,
-            response_convertor=lambda response: OpenID(
+            response_convertor=lambda response, _: OpenID(
                 id=response["id"], email=response["email"], display_name=response["display_name"]
             ),
         )


### PR DESCRIPTION
This will make it easier to allow
SSO subclasses to enhance response
with data from other provider-specific endpoints.

Suggested by @Cereal84 