### PR TITLE
Follow PEP 561 - Distributing and Packaging Type Information

### DIFF
--- a/fastapi_sso/sso/microsoft.py
+++ b/fastapi_sso/sso/microsoft.py
@@ -1,6 +1,8 @@
 """Microsoft SSO Oauth Helper class"""
 
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Union
+
+import pydantic
 
 from fastapi_sso.sso.base import DiscoveryDocument, OpenID, SSOBase
 
@@ -20,7 +22,7 @@ class MicrosoftSSO(SSOBase):
         self,
         client_id: str,
         client_secret: str,
-        redirect_uri: Optional[str] = None,
+        redirect_uri: Optional[Union[pydantic.AnyHttpUrl, str]] = None,
         allow_insecure_http: bool = False,
         use_state: bool = False,  # TODO: Remove use_state argument
         scope: Optional[List[str]] = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-sso"
-version = "0.7.3"
+version = "0.7.4"
 description = "FastAPI plugin to enable SSO to most common providers (such as Facebook login, Google login and login via Microsoft Office 365 Account)"
 authors = ["Tomas Votava <info@tomasvotava.eu>"]
 readme = "README.md"
@@ -9,6 +9,7 @@ repository = "https://github.com/tomasvotava/fastapi-sso"
 homepage = "https://tomasvotava.github.io/fastapi-sso/"
 documentation = "https://tomasvotava.github.io/fastapi-sso/"
 keywords = ["fastapi", "sso", "oauth", "google", "facebook", "spotify"]
+include = ["fastapi_sso/py.typed"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests/"]


### PR DESCRIPTION
The current application does not follow the PEP 561, which means all projects that use `fastapi_sso` and the mypy should ignore all imports.

```bash
python -m mypy --check-untyped-defs .
foo.py:6: error: Skipping analyzing "fastapi_sso": module is installed, but missing library stubs or py.typed marker  [import-untyped]
foo.py:6: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
```

This PR makes it easier to integrate this package into the whole FastAPI, pydantic, mypy, ... ecosystem