### PR TITLE
Python3.12 support is added

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Apple specific
+.DS_Store

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py38,py39,py310,py311
+envlist = py38,py39,py310,py311,py312
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Since Python3.12 is compatible with Python3.11 it should be added to the TOX checker as a latest stable product