### PR TITLE
fix: linkedin API may not return all required data in the response

### DIFF
--- a/fastapi_sso/sso/linkedin.py
+++ b/fastapi_sso/sso/linkedin.py
@@ -30,8 +30,8 @@ class LinkedInSSO(SSOBase):
         return OpenID(
             email=response.get("email"),
             provider=self.provider,
-            id=response["sub"],
-            first_name=response["given_name"],
-            last_name=response["family_name"],
-            picture=response["picture"],
+            id=response.get("sub"),
+            first_name=response.get("given_name"),
+            last_name=response.get("family_name"),
+            picture=response.get("picture"),
         )


### PR DESCRIPTION
Closes #137 
