### PR TITLE
Fix GitLab OpenID instance as it breaks with latest pydantic

### DIFF
--- a/fastapi_sso/sso/gitlab.py
+++ b/fastapi_sso/sso/gitlab.py
@@ -26,7 +26,7 @@ class GitlabSSO(SSOBase):
         return OpenID(
             email=response["email"],
             provider=self.provider,
-            id=response["id"],
+            id=str(response["id"]),
             display_name=response["username"],
             picture=response["avatar_url"],
         )


### PR DESCRIPTION
Latest versions of Pydantic reject objects that are not created with their values aligned to their hints.

This results in GitLab SSO breaking when trying to form the OpenID object, as the response from GitLab comes with an int for the 'id' field while OpenID pydantic model expects a string.

Fix is simple and easy with just casting the field to string when creating the object in openid_from_response of GitlabSSO class.