### PR TITLE
fix(gitlab): added support for on-premise gitlab, first name and last name

### DIFF
--- a/examples/gitlab.py
+++ b/examples/gitlab.py
@@ -8,12 +8,14 @@ from fastapi_sso.sso.gitlab import GitlabSSO
 
 CLIENT_ID = os.environ["CLIENT_ID"]
 CLIENT_SECRET = os.environ["CLIENT_SECRET"]
+BASE_ENDPOINT_URL = os.environ.get("GITLAB_ENDPOINT_URL", "https://gitlab.com")
 
 app = FastAPI()
 
 sso = GitlabSSO(
     client_id=CLIENT_ID,
     client_secret=CLIENT_SECRET,
+    base_endpoint_url=BASE_ENDPOINT_URL,
     redirect_uri="http://localhost:5000/auth/callback",
     allow_insecure_http=True,
 )

--- a/fastapi_sso/sso/gitlab.py
+++ b/fastapi_sso/sso/gitlab.py
@@ -50,7 +50,7 @@ class GitlabSSO(SSOBase):
 
     def _parse_name(self, full_name: Optional[str]) -> Tuple[Union[str, None], Union[str, None]]:
         """Parses the full name from Gitlab into the first and last name."""
-        if not full_name:
+        if not full_name or not isinstance(full_name, str):
             return None, None
 
         name_parts = full_name.split()

--- a/fastapi_sso/sso/gitlab.py
+++ b/fastapi_sso/sso/gitlab.py
@@ -1,6 +1,7 @@
 """Gitlab SSO Oauth Helper class"""
 
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from urllib.parse import urljoin
 
 import pydantic
 
@@ -22,11 +23,11 @@ class GitlabSSO(SSOBase):
         self,
         client_id: str,
         client_secret: str,
-        base_endpoint_url: Optional[Union[pydantic.AnyHttpUrl, str]] = None,
-        redirect_uri: Any | str | None = None,
+        redirect_uri: Optional[Union[pydantic.AnyHttpUrl, str]] = None,
         allow_insecure_http: bool = False,
         use_state: bool = False,  # TODO: Remove use_state argument
-        scope: List[str] | None = None,
+        scope: Optional[List[str]] = None,
+        base_endpoint_url: Optional[str] = None,
     ) -> None:
         super().__init__(
             client_id,
@@ -39,17 +40,38 @@ class GitlabSSO(SSOBase):
         self.base_endpoint_url = base_endpoint_url or self.base_endpoint_url
 
     async def get_discovery_document(self) -> DiscoveryDocument:
+        """Override the discovery document method to return Yandex OAuth endpoints."""
+
         return {
-            "authorization_endpoint": f"{self.base_endpoint_url}/oauth/authorize",
-            "token_endpoint": f"{self.base_endpoint_url}/oauth/token",
-            "userinfo_endpoint": f"{self.base_endpoint_url}/api/v4/user",
+            "authorization_endpoint": urljoin(self.base_endpoint_url, "/oauth/authorize"),
+            "token_endpoint": urljoin(self.base_endpoint_url, "/oauth/token"),
+            "userinfo_endpoint": urljoin(self.base_endpoint_url, "/api/v4/user"),
         }
 
+    def _parse_name(self, full_name: Optional[str]) -> Tuple[Union[str, None], Union[str, None]]:
+        """Parses the full name from Gitlab into the first and last name."""
+        if not full_name:
+            return None, None
+
+        name_parts = full_name.split()
+
+        if len(name_parts) == 1:
+            return name_parts[0], None
+
+        first_name = name_parts[0]
+        last_name = " ".join(name_parts[1:])
+        return first_name, last_name
+
     async def openid_from_response(self, response: dict, session: Optional["httpx.AsyncClient"] = None) -> OpenID:
+        """Converts Gitlab user info response to OpenID object."""
+        first_name, last_name = self._parse_name(response.get("name"))
+
         return OpenID(
             email=response["email"],
             provider=self.provider,
             id=str(response["id"]),
+            first_name=first_name,
+            last_name=last_name,
             display_name=response["username"],
             picture=response["avatar_url"],
         )

--- a/tests/test_openid_responses.py
+++ b/tests/test_openid_responses.py
@@ -136,6 +136,26 @@ sso_test_cases: Tuple[Type[SSOBase], Tuple[Dict[str, Any], OpenID]] = (
         ),
     ),
     (
+        # Gitlab Case 5: full name contains invalid type or data
+        GitlabSSO,
+        {
+            "email": "test@example.com",
+            "id": "test",
+            "username": "test_user",
+            "avatar_url": "https://myimage",
+            "name": {"invalid": 1},
+        },
+        OpenID(
+            email="test@example.com",
+            id="test",
+            display_name="test_user",
+            picture="https://myimage",
+            first_name=None,
+            last_name=None,
+            provider="gitlab",
+        ),
+    ),
+    (
         GithubSSO,
         {"email": "test@example.com", "id": "test", "login": "testuser", "avatar_url": "https://myimage"},
         OpenID(

--- a/tests/test_openid_responses.py
+++ b/tests/test_openid_responses.py
@@ -14,19 +14,22 @@ from fastapi_sso.sso.github import GithubSSO
 from fastapi_sso.sso.fitbit import FitbitSSO
 from fastapi_sso.sso.facebook import FacebookSSO
 
-sso_mapping: Dict[Type[SSOBase], Tuple[Dict[str, Any], OpenID]] = {
-    TwitterSSO: (
+sso_test_cases: Tuple[Type[SSOBase], Tuple[Dict[str, Any], OpenID]] = (
+    (
+        TwitterSSO,
         {"data": {"id": "test", "username": "TestUser1234", "name": "Test User"}},
         OpenID(id="test", display_name="TestUser1234", first_name="Test", last_name="User", provider="twitter"),
     ),
-    SpotifySSO: (
+    (
+        SpotifySSO,
         {"email": "test@example.com", "display_name": "testuser", "id": "test", "images": [{"url": "https://myimage"}]},
         OpenID(
             id="test", provider="spotify", display_name="testuser", email="test@example.com", picture="https://myimage"
         ),
     ),
-    NaverSSO: ({"properties": {"nickname": "test"}}, OpenID(display_name="test", provider="naver")),
-    MicrosoftSSO: (
+    (NaverSSO, {"properties": {"nickname": "test"}}, OpenID(display_name="test", provider="naver")),
+    (
+        MicrosoftSSO,
         {"mail": "test@example.com", "displayName": "Test User", "id": "test", "givenName": "Test", "surname": "User"},
         OpenID(
             email="test@example.com",
@@ -37,7 +40,8 @@ sso_mapping: Dict[Type[SSOBase], Tuple[Dict[str, Any], OpenID]] = {
             last_name="User",
         ),
     ),
-    LinkedInSSO: (
+    (
+        LinkedInSSO,
         {
             "email": "test@example.com",
             "sub": "test",
@@ -54,30 +58,92 @@ sso_mapping: Dict[Type[SSOBase], Tuple[Dict[str, Any], OpenID]] = {
             picture="https://myimage",
         ),
     ),
-    LineSSO: (
+    (
+        LineSSO,
         {"email": "test@example.com", "name": "Test User", "sub": "test", "picture": "https://myimage"},
         OpenID(
             email="test@example.com", display_name="Test User", id="test", picture="https://myimage", provider="line"
         ),
     ),
-    KakaoSSO: ({"properties": {"nickname": "Test User"}}, OpenID(provider="kakao", display_name="Test User")),
-    GitlabSSO: (
+    (KakaoSSO, {"properties": {"nickname": "Test User"}}, OpenID(provider="kakao", display_name="Test User")),
+    (
+        GitlabSSO,
         {"email": "test@example.com", "id": "test", "username": "test_user", "avatar_url": "https://myimage"},
         OpenID(
             email="test@example.com", id="test", display_name="test_user", picture="https://myimage", provider="gitlab"
         ),
     ),
-    GithubSSO: (
+    (
+        GitlabSSO,
+        {
+            "email": "test@example.com",
+            "id": "test",
+            "username": "test_user",
+            "avatar_url": "https://myimage",
+            "name": "Test",
+        },
+        OpenID(
+            email="test@example.com",
+            id="test",
+            display_name="test_user",
+            picture="https://myimage",
+            first_name="Test",
+            last_name=None,
+            provider="gitlab",
+        ),
+    ),
+    (
+        GitlabSSO,
+        {
+            "email": "test@example.com",
+            "id": "test",
+            "username": "test_user",
+            "avatar_url": "https://myimage",
+            "name": "Test User Long Last Name",
+        },
+        OpenID(
+            email="test@example.com",
+            id="test",
+            display_name="test_user",
+            picture="https://myimage",
+            first_name="Test",
+            last_name="User Long Last Name",
+            provider="gitlab",
+        ),
+    ),
+    (
+        GitlabSSO,
+        {
+            "email": "test@example.com",
+            "id": "test",
+            "username": "test_user",
+            "avatar_url": "https://myimage",
+            "name": "Test User",
+        },
+        OpenID(
+            email="test@example.com",
+            id="test",
+            display_name="test_user",
+            picture="https://myimage",
+            first_name="Test",
+            last_name="User",
+            provider="gitlab",
+        ),
+    ),
+    (
+        GithubSSO,
         {"email": "test@example.com", "id": "test", "login": "testuser", "avatar_url": "https://myimage"},
         OpenID(
             email="test@example.com", id="test", display_name="testuser", picture="https://myimage", provider="github"
         ),
     ),
-    FitbitSSO: (
+    (
+        FitbitSSO,
         {"user": {"encodedId": "test", "fullName": "Test", "displayName": "Test User", "avatar": "https://myimage"}},
         OpenID(id="test", first_name="Test", display_name="Test User", provider="fitbit", picture="https://myimage"),
     ),
-    FacebookSSO: (
+    (
+        FacebookSSO,
         {
             "email": "test@example.com",
             "first_name": "Test",
@@ -96,12 +162,10 @@ sso_mapping: Dict[Type[SSOBase], Tuple[Dict[str, Any], OpenID]] = {
             picture="https://myimage",
         ),
     ),
-}
-
-
-@pytest.mark.parametrize(
-    ("ProviderClass", "response", "openid"), [(key, value[0], value[1]) for key, value in sso_mapping.items()]
 )
+
+
+@pytest.mark.parametrize(("ProviderClass", "response", "openid"), sso_test_cases)
 async def test_provider_openid_by_response(
     ProviderClass: Type[SSOBase], response: Dict[str, Any], openid: OpenID
 ) -> None:


### PR DESCRIPTION
Hello! 

The current Gitlab implementation does not support the use of authentication via on-premise Gitlab. 

In order not to make patches on the client side, I'm making a small edit that adds only one parameter for init the provider with the default value.