### PR TITLE
[hotfix] add naver email, nickname fields(optinal).

### DIFF
--- a/fastapi_sso/sso/naver.py
+++ b/fastapi_sso/sso/naver.py
@@ -25,7 +25,8 @@ class NaverSSO(SSOBase):
     async def openid_from_response(self, response: dict, session: Optional["httpx.AsyncClient"] = None) -> OpenID:
         return OpenID(
             id=response["response"]["id"],
-            display_name=response["response"]["nickname"],
+            email=response["response"]["email"] or None,
+            display_name=response["response"]["nickname"] or None,
             picture=response["response"]["profile_image"] or None,
             provider=self.provider,
         )

--- a/fastapi_sso/sso/naver.py
+++ b/fastapi_sso/sso/naver.py
@@ -25,8 +25,8 @@ class NaverSSO(SSOBase):
     async def openid_from_response(self, response: dict, session: Optional["httpx.AsyncClient"] = None) -> OpenID:
         return OpenID(
             id=response["response"]["id"],
-            email=response["response"]["email"] or None,
-            display_name=response["response"]["nickname"] or None,
-            picture=response["response"]["profile_image"] or None,
+            email=response["response"].get("email"),
+            display_name=response["response"].get("nickname"),
+            picture=response["response"].get("profile_image"),
             provider=self.provider,
         )

--- a/tests/test_openid_responses.py
+++ b/tests/test_openid_responses.py
@@ -30,8 +30,8 @@ sso_test_cases: Tuple[Tuple[Type[SSOBase], Dict[str, Any], OpenID], ...] = (
     ),
     (
         NaverSSO,
-        {"response": {"nickname": "test", "profile_image": "https://myimage", "id": "test"}},
-        OpenID(id="test", display_name="test", provider="naver", picture="https://myimage"),
+        {"response": {"nickname": "test", "profile_image": "https://myimage", "id": "test", "email": "test@example.com"}},
+        OpenID(id="test", email="test@example.com", display_name="test", provider="naver", picture="https://myimage"),
     ),
     (
         MicrosoftSSO,


### PR DESCRIPTION
Sorry about its.

<img width="824" alt="image" src="https://github.com/tomasvotava/fastapi-sso/assets/11470513/aa0768cd-2774-4592-8f50-ecc4c5500e25">

Naver sets the DisplayName, email, and Picture fields as optional fields. Photo options include: I didn't check this part properly when doing PR. I'm sorry for uploading a hotfix again with duplicate content.